### PR TITLE
use .bytes instead of .chars to avoid utf encoding issues

### DIFF
--- a/lib/amq/hacks.rb
+++ b/lib/amq/hacks.rb
@@ -18,11 +18,11 @@ module AMQ
     else
       def self.pack_64_big_endian(long_long)
         result = [long_long].pack(Q)
-        result.chars.to_a.reverse.join
+        result.bytes.to_a.reverse.map(&:chr).join
       end
 
       def self.unpack_64_big_endian(data)
-        data = data.chars.to_a.reverse.join
+        data = data.bytes.to_a.reverse.map(&:chr).join
         data.unpack(Q)
       end
     end

--- a/spec/amq/hacks_spec.rb
+++ b/spec/amq/hacks_spec.rb
@@ -19,21 +19,42 @@ module AMQ
         }
       }
 
-      describe ".pack_64_big_endian" do
-        it "packs integers into big-endian string" do
-          examples.each do |key, value|
-            described_class.pack_64_big_endian(key).should == value
-          end
+      it "packs integers into big-endian string" do
+        examples.each do |key, value|
+          described_class.pack_64_big_endian(key).should == value
         end
       end
 
-      describe ".unpack_64_big_endian" do
-        it "should unpack string representation into integer" do
-          examples.each do |key, value|
-            described_class.unpack_64_big_endian(value)[0].should == key
+      it "should unpack string representation into integer" do
+        examples.each do |key, value|
+          described_class.unpack_64_big_endian(value)[0].should == key
+        end
+      end
+      
+      if RUBY_VERSION < '1.9'
+        describe "with utf encoding" do
+          before do
+            $KCODE = 'u'
+          end
+          
+          after do 
+            $KCODE = 'NONE'
+          end
+          
+          it "packs integers into big-endian string" do
+            examples.each do |key, value|
+              described_class.pack_64_big_endian(key).should == value
+            end
+          end
+
+          it "should unpack string representation into integer" do
+            examples.each do |key, value|
+              described_class.unpack_64_big_endian(value)[0].should == key
+            end
           end
         end
       end
+      
     end
   end
 end


### PR DESCRIPTION
The problem shows up when you changed the default encoding in Ruby 1.8.x ($KCODE = 'u'). Rails does this by default. 

https://github.com/ruby-amqp/amqp/issues/107

I usually work with test unit, so let me know if there is a better way to do the spec.
