### PR TITLE
Adding license information

### DIFF
--- a/amq-protocol.gemspec
+++ b/amq-protocol.gemspec
@@ -17,6 +17,7 @@ Gem::Specification.new do |s|
   If you want to write your own AMQP client, this gem can help you with that.
   DESC
   s.email = ["bWljaGFlbEBub3ZlbWJlcmFpbi5jb20=\n", "c3Rhc3RueUAxMDFpZGVhcy5jeg==\n"].map { |i| Base64.decode64(i) }
+  s.licenses    = ["MIT"]
 
   # files
   s.files = `git ls-files`.split("\n").reject { |file| file =~ /^vendor\// }


### PR DESCRIPTION
Hi,

I use an automatic tool to track the licenses of the libraries I use and I noticed this gem doesn't specify the license in the gemspec. I'd really like to be able to track your gem using this tool. I'm submitting a pull request to change this.

Thanks,
Andrew
