### PR TITLE
Require date so that DateTime constant is found

### DIFF
--- a/lib/amq/protocol/table_value_encoder.rb
+++ b/lib/amq/protocol/table_value_encoder.rb
@@ -3,6 +3,7 @@
 require "amq/protocol/client"
 require "amq/protocol/type_constants"
 require "amq/protocol/table"
+require "date"
 
 module AMQ
   module Protocol


### PR DESCRIPTION
I patched table_value_encoder.rb by adding a require 'date' because I got the following error when I was testing some Bunny code -

/home/chris/.rvm/gems/ruby-1.9.3-p286/gems/amq-protocol-1.0.0/lib/amq/protocol/table_value_encoder.rb:91:in `field_value_size': uninitialized constant AMQ::Protocol::TableValueEncoder::DateTime (NameError)

This is the code that I was running -

require 'bunny'

connection = Bunny.new
connection.start

ch = connection.create_channel
q = connection.queue('', :exclusive => true)
x  = ch.default_exchange
# access on the consumer side

q.subscribe(:exclusive => true, :ack => false) do |delivery_info, properties, payload|
  puts properties.content_type # => "application/octet-stream"
  puts properties.priority     # => 8

  puts properties.headers["time"] # => a Time instance

  puts properties.headers["coordinates"]["latitude"] # => 59.35
  puts properties.headers["participants"]            # => 11
  puts properties.headers["venue"]                   # => "Stockholm"
  puts properties.headers["true_field"]              # => true
  puts properties.headers["false_field"]             # => false
  puts properties.headers["nil_field"]               # => nil
  puts properties.headers["ary_field"]               # => ["one", 2.0, 3, [{ "abc" => 123}]]

  puts properties.timestamp      # => a Time instance
  puts properties.type           # => "kinda.checkin"
  puts properties.reply_to       # => "a.sender"
  puts properties.correlation_id # => "r-1"
  puts properties.message_id     # => "m-1"
  puts properties.app_id         # => "bunny.example"

  puts delivery_info.consumer_tag # => a string
  puts delivery_info.redelivered? # => false
  puts delivery_info.delivery_tag # => 1
  puts delivery_info.routing_key  # => "bunny.examples.message_properties"
  puts delivery_info.exchange     # => ""
end
# publishing

x.publish("hello",
          :routing_key => "#{q.name}",
          :app_id      => "bunny.example",
          :priority    => 8,
          :type        => "kinda.checkin",
          # headers table keys can be anything
          :headers     => {
            :coordinates => {
              :latitude  => 59.35,
              :longitude => 18.066667
            },
            :time         => Time.now,
            :participants => 11,
            :venue        => "Stockholm",
            :true_field   => true,
            :false_field  => false,
            :nil_field    => nil,
            :ary_field    => ["one", 2.0, 3, [{"abc" => 123}]]
          },
          :timestamp      => Time.now.to_i,
          :reply_to       => "a.sender",
          :correlation_id => "r-1",
          :message_id     => "m-1")

sleep 1.0
connection.close
