### PR TITLE
Fix framing issue in the encode_body() method

### DIFF
--- a/lib/amq/protocol/client.rb
+++ b/lib/amq/protocol/client.rb
@@ -177,7 +177,7 @@ module AMQ
         body.force_encoding("ASCII-8BIT") if RUBY_VERSION.to_f >= 1.9
 
         array = Array.new
-        while body
+        while body && !body.empty?
           payload, body = body[0, limit], body[limit, body.length - limit]
           array << BodyFrame.new(payload, channel)
         end

--- a/spec/amq/protocol/method_spec.rb
+++ b/spec/amq/protocol/method_spec.rb
@@ -34,6 +34,14 @@ module AMQ
             body_frames.map(&:payload).should == lipsum.split('').each_slice(expected_payload_size).map(&:join)
           end
         end
+
+        context 'when the body fits perfectly in a single frame' do
+          it 'encodes a body into a single BodyFrame' do
+            body_frames = Method.encode_body('*' * 131064, 1, 131072)
+            body_frames.first.payload.should == '*' * 131064
+            body_frames.should have(1).item
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
When the payload is frame_size - 8, encode_body generate an extra frame of 0 length. This makes RabbitMQ angry.
