### PR TITLE
Use the correct version constraint for the RSpec dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,6 @@ group :development do
 end
 
 group :test do
-  gem "rspec", ">= 2.13.0"
+  gem "rspec", "~> 2.13.0"
   gem "effin_utf8"
 end


### PR DESCRIPTION
The current release of RSpec is v3._x_. It is incompatible with the specs defined in amq-protocol due to the elimination of such constructs as `its` blocks.

Without this change to the version constraint, the project’s specs cannot be run after bundling on an empty gemset.
