### PR TITLE
Use the correct platform constraint for the ruby-prof dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ source "https://rubygems.org"
 
 group :development do
   # excludes Windows, Rubinius and JRuby
-  gem "ruby-prof", :platform => :mri
+  gem "ruby-prof", :platforms => [:mri_19, :mri_20, :mri_21]
 
   gem "rake"
 end


### PR DESCRIPTION
The ruby-prof gem requires Ruby v1.9.3 or newer.

Without this change to the platform constraint, the project cannot be bundled on an empty gemset under Ruby v1.8._x_.
