### PR TITLE
Remove warnings about URI.unescape being deprecated

### DIFF
--- a/lib/amq/uri.rb
+++ b/lib/amq/uri.rb
@@ -18,14 +18,14 @@ module AMQ
       opts = {}
 
       opts[:scheme] = uri.scheme
-      opts[:user]   = ::URI.unescape(uri.user) if uri.user
-      opts[:pass]   = ::URI.unescape(uri.password) if uri.password
+      opts[:user]   = ::CGI::unescape(uri.user) if uri.user
+      opts[:pass]   = ::CGI::unescape(uri.password) if uri.password
       opts[:host]   = uri.host if uri.host
       opts[:port]   = uri.port || AMQP_PORTS[uri.scheme]
       opts[:ssl]    = uri.scheme.to_s.downcase =~ /amqps/i
       if uri.path =~ %r{^/(.*)}
         raise ArgumentError.new("#{uri} has multiple-segment path; please percent-encode any slashes in the vhost name (e.g. /production => %2Fproduction). Learn more at http://bit.ly/amqp-gem-and-connection-uris") if $1.index('/')
-        opts[:vhost] = ::URI.unescape($1)
+        opts[:vhost] = ::CGI::unescape($1)
       end
 
       opts


### PR DESCRIPTION
Per this answer on stackoverflow: http://stackoverflow.com/a/2832003