### PR TITLE
most of the way to rspec 3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,7 @@ group :development do
 end
 
 group :test do
-  gem "rspec", "~> 2.13.0"
+  gem "rspec"
+  gem "rspec-its"
   gem "effin_utf8"
 end

--- a/lib/amq/uri.rb
+++ b/lib/amq/uri.rb
@@ -1,7 +1,5 @@
 # encoding: utf-8
 
-require "amq/settings"
-
 require "cgi"
 require "uri"
 

--- a/spec/amq/bit_set_spec.rb
+++ b/spec/amq/bit_set_spec.rb
@@ -23,7 +23,7 @@ describe AMQ::BitSet do
     it "has no bits set at the start" do
       bs = AMQ::BitSet.new(128)
       0.upto(127) do |i|
-        bs[i].should == false
+        expect(bs[i]).to be_falsey
       end
     end # it
   end # describe
@@ -33,15 +33,15 @@ describe AMQ::BitSet do
       described_class.new(nbits)
     end
     it "returns 0 when the word is between 0 and 63" do
-      subject.word_index(0).should == 0
-      subject.word_index(63).should == 0
+      expect(subject.word_index(0)).to eq(0)
+      expect(subject.word_index(63)).to eq(0)
     end # it
     it "returns 1 when the word is between 64 and 127" do
-      subject.word_index(64).should == 1
-      subject.word_index(127).should == 1
+      expect(subject.word_index(64)).to be(1)
+      expect(subject.word_index(127)).to be(1)
     end # it
     it "returns 2 when the word is between 128 and another number" do
-      subject.word_index(128).should == 2
+      expect(subject.word_index(128)).to be(2)
     end # it
   end # describe
 
@@ -54,7 +54,7 @@ describe AMQ::BitSet do
       end
 
       it "returns true" do
-        subject.get(3).should be_true
+        expect(subject.get(3)).to be_truthy
       end # it
     end # describe
 
@@ -64,7 +64,7 @@ describe AMQ::BitSet do
       end
 
       it "returns false" do
-        subject.get(5).should be_false
+        expect(subject.get(5)).to be_falsey
       end # it
     end # describe
 
@@ -74,10 +74,10 @@ describe AMQ::BitSet do
       end
 
       it "should raise IndexError for negative index" do
-        lambda { subject.get(-1) }.should raise_error(IndexError)
+        expect { subject.get(-1) }.to raise_error(IndexError)
       end # it
       it "should raise IndexError for index >= number of bits" do
-        lambda { subject.get(nbits) }.should raise_error(IndexError)
+        expect { subject.get(nbits) }.to raise_error(IndexError)
       end # it
     end # describe
   end # describe
@@ -91,9 +91,9 @@ describe AMQ::BitSet do
 
       it "has no effect" do
         subject.set(3)
-        subject.get(3).should be_true
+        expect(subject.get(3)).to be_truthy
         subject.set(3)
-        subject[3].should be_true
+        expect(subject[3]).to be_truthy
       end # it
     end # describe
 
@@ -104,13 +104,13 @@ describe AMQ::BitSet do
 
       it "sets that bit" do
         subject.set(3)
-        subject.get(3).should be_true
+        expect(subject.get(3)).to be_truthy
 
         subject.set(33)
-        subject.get(33).should be_true
+        expect(subject.get(33)).to be_truthy
 
         subject.set(3387)
-        subject.get(3387).should be_true
+        expect(subject.get(3387)).to be_truthy
       end # it
     end # describe
 
@@ -120,10 +120,10 @@ describe AMQ::BitSet do
       end
 
       it "should raise IndexError for negative index" do
-        lambda { subject.set(-1) }.should raise_error(IndexError)
+        expect { subject.set(-1) }.to raise_error(IndexError)
       end # it
       it "should raise IndexError for index >= number of bits" do
-        lambda { subject.set(nbits) }.should raise_error(IndexError)
+        expect { subject.set(nbits) }.to raise_error(IndexError)
       end # it
     end # describe
   end # describe
@@ -137,9 +137,9 @@ describe AMQ::BitSet do
 
       it "unsets that bit" do
         subject.set(3)
-        subject.get(3).should be_true
+        expect(subject.get(3)).to be_truthy
         subject.unset(3)
-        subject.get(3).should be_false
+        expect(subject.get(3)).to be_falsey
       end # it
     end # describe
 
@@ -150,9 +150,9 @@ describe AMQ::BitSet do
       end
 
       it "has no effect" do
-        subject.get(3).should be_false
+        expect(subject.get(3)).to be_falsey
         subject.unset(3)
-        subject.get(3).should be_false
+        expect(subject.get(3)).to be_falsey
       end # it
     end # describe
 
@@ -162,10 +162,10 @@ describe AMQ::BitSet do
       end
 
       it "should raise IndexError for negative index" do
-        lambda { subject.unset(-1) }.should raise_error(IndexError)
+        expect { subject.unset(-1) }.to raise_error(IndexError)
       end # it
       it "should raise IndexError for index >= number of bits" do
-        lambda { subject.unset(nbits) }.should raise_error(IndexError)
+        expect { subject.unset(nbits) }.to raise_error(IndexError)
       end # it
     end # describe
   end # describe
@@ -179,25 +179,25 @@ describe AMQ::BitSet do
 
     it "clears all bits" do
       subject.set(3)
-      subject.get(3).should be_true
+      expect(subject.get(3)).to be_truthy
 
       subject.set(7668)
-      subject.get(7668).should be_true
+      expect(subject.get(7668)).to be_truthy
 
       subject.clear
 
-      subject.get(3).should be_false
-      subject.get(7668).should be_false
+      expect(subject.get(3)).to be_falsey
+      expect(subject.get(7668)).to be_falsey
     end # it
   end # describe
 
   describe "#number_of_trailing_ones" do
     it "calculates them" do
-      described_class.number_of_trailing_ones(0).should == 0
-      described_class.number_of_trailing_ones(1).should == 1
-      described_class.number_of_trailing_ones(2).should == 0
-      described_class.number_of_trailing_ones(3).should == 2
-      described_class.number_of_trailing_ones(4).should == 0
+      expect(described_class.number_of_trailing_ones(0)).to eq(0)
+      expect(described_class.number_of_trailing_ones(1)).to eq(1)
+      expect(described_class.number_of_trailing_ones(2)).to eq(0)
+      expect(described_class.number_of_trailing_ones(3)).to eq(2)
+      expect(described_class.number_of_trailing_ones(4)).to eq(0)
     end # it
   end # describe
 
@@ -206,27 +206,27 @@ describe AMQ::BitSet do
       described_class.new(255)
     end
     it "returns sequential values when none have been returned" do
-      subject.next_clear_bit.should == 0
+      expect(subject.next_clear_bit).to eq(0)
       subject.set(0)
-      subject.next_clear_bit.should == 1
+      expect(subject.next_clear_bit).to eq(1)
       subject.set(1)
-      subject.next_clear_bit.should == 2
+      expect(subject.next_clear_bit).to eq(2)
       subject.unset(1)
-      subject.next_clear_bit.should == 1
+      expect(subject.next_clear_bit).to eq(1)
     end # it
 
     it "returns the same number as long as nothing is set" do
-      subject.next_clear_bit.should == 0
-      subject.next_clear_bit.should == 0
+      expect(subject.next_clear_bit).to eq(0)
+      expect(subject.next_clear_bit).to eq(0)
     end # it
 
     it "handles more than 128 bits" do
       0.upto(254) do |i|
         subject.set(i)
-        subject.next_clear_bit.should == i + 1
+        expect(subject.next_clear_bit).to eq(i + 1)
       end
       subject.unset(254)
-      subject.get(254).should be_false
+      expect(subject.get(254)).to be_falsey
     end # it
   end # describe
 end

--- a/spec/amq/int_allocator_spec.rb
+++ b/spec/amq/int_allocator_spec.rb
@@ -23,20 +23,20 @@ describe AMQ::IntAllocator do
 
   describe "#number_of_bits" do
     it "returns number of bits available for allocation" do
-      subject.number_of_bits.should == 4
+      expect(subject.number_of_bits).to eq(4)
     end
   end
 
 
   describe "#hi" do
     it "returns upper bound of the allocation range" do
-      subject.hi.should == 5
+      expect(subject.hi).to eq(5)
     end
   end
 
   describe "#lo" do
     it "returns lower bound of the allocation range" do
-      subject.lo.should == 1
+      expect(subject.lo).to eq(1)
     end
   end
 
@@ -44,12 +44,12 @@ describe AMQ::IntAllocator do
   describe "#allocate" do
     context "when integer in the range is available" do
       it "returns allocated integer" do
-        subject.allocate.should == 1
-        subject.allocate.should == 2
-        subject.allocate.should == 3
-        subject.allocate.should == 4
+        expect(subject.allocate).to eq(1)
+        expect(subject.allocate).to eq(2)
+        expect(subject.allocate).to eq(3)
+        expect(subject.allocate).to eq(4)
 
-        subject.allocate.should == -1
+        expect(subject.allocate).to eq(-1)
       end
     end
 
@@ -57,10 +57,10 @@ describe AMQ::IntAllocator do
       it "returns -1" do
         4.times { subject.allocate }
 
-        subject.allocate.should == -1
-        subject.allocate.should == -1
-        subject.allocate.should == -1
-        subject.allocate.should == -1
+        expect(subject.allocate).to eq(-1)
+        expect(subject.allocate).to eq(-1)
+        expect(subject.allocate).to eq(-1)
+        expect(subject.allocate).to eq(-1)
       end
     end
   end
@@ -70,24 +70,24 @@ describe AMQ::IntAllocator do
     context "when the integer WAS allocated" do
       it "returns frees that integer" do
         4.times { subject.allocate }
-        subject.allocate.should == -1
+        expect(subject.allocate).to eq(-1)
 
         subject.free(1)
-        subject.allocate.should == 1
-        subject.allocate.should == -1
+        expect(subject.allocate).to eq(1)
+        expect(subject.allocate).to eq(-1)
         subject.free(2)
-        subject.allocate.should == 2
-        subject.allocate.should == -1
+        expect(subject.allocate).to eq(2)
+        expect(subject.allocate).to eq(-1)
         subject.free(3)
-        subject.allocate.should == 3
-        subject.allocate.should == -1
+        expect(subject.allocate).to eq(3)
+        expect(subject.allocate).to eq(-1)
       end
     end
 
     context "when the integer WAS NOT allocated" do
       it "has no effect" do
         32.times { subject.free(1) }
-        subject.allocate.should == 1
+        expect(subject.allocate).to eq(1)
       end
     end
   end
@@ -98,9 +98,9 @@ describe AMQ::IntAllocator do
       it "returns true" do
         3.times { subject.allocate }
 
-        subject.allocated?(1).should be_true
-        subject.allocated?(2).should be_true
-        subject.allocated?(3).should be_true
+        expect(subject.allocated?(1)).to be_truthy
+        expect(subject.allocated?(2)).to be_truthy
+        expect(subject.allocated?(3)).to be_truthy
       end
     end
 
@@ -108,8 +108,8 @@ describe AMQ::IntAllocator do
       it "returns false" do
         2.times { subject.allocate }
 
-        subject.allocated?(3).should be_false
-        subject.allocated?(4).should be_false
+        expect(subject.allocated?(3)).to be_falsey
+        expect(subject.allocated?(4)).to be_falsey
       end
     end
   end

--- a/spec/amq/pack_spec.rb
+++ b/spec/amq/pack_spec.rb
@@ -14,7 +14,7 @@ module AMQ
 
       it "unpacks signed integers from a string to a number" do
         examples_16bit.each do |key, value|
-          described_class.unpack_int16_big_endian(value)[0].should == key
+          expect(described_class.unpack_int16_big_endian(value)[0]).to eq(key)
         end
       end
     end
@@ -37,13 +37,13 @@ module AMQ
 
       it "packs integers into big-endian string" do
         examples.each do |key, value|
-          described_class.pack_uint64_big_endian(key).should == value
+          expect(described_class.pack_uint64_big_endian(key)).to eq(value)
         end
       end
 
       it "should unpack string representation into integer" do
         examples.each do |key, value|
-          described_class.unpack_uint64_big_endian(value)[0].should == key
+          expect(described_class.unpack_uint64_big_endian(value)[0]).to eq(key)
         end
       end
 
@@ -59,13 +59,13 @@ module AMQ
 
           it "packs integers into big-endian string" do
             examples.each do |key, value|
-              described_class.pack_uint64_big_endian(key).should == value
+              expect(described_class.pack_uint64_big_endian(key)).to eq(value)
             end
           end
 
           it "should unpack string representation into integer" do
             examples.each do |key, value|
-              described_class.unpack_uint64_big_endian(value)[0].should == key
+              expect(described_class.unpack_uint64_big_endian(value)[0]).to eq(key)
             end
           end
         end

--- a/spec/amq/protocol/basic_spec.rb
+++ b/spec/amq/protocol/basic_spec.rb
@@ -8,58 +8,58 @@ module AMQ
     describe Basic do
       describe '.encode_timestamp' do
         it 'encodes the timestamp as a 64 byte big endian integer' do
-          Basic.encode_timestamp(12345).last.should == "\x00\x00\x00\x00\x00\x0009"
+          expect(Basic.encode_timestamp(12345).last).to eq("\x00\x00\x00\x00\x00\x0009")
         end
       end
       
       # describe '.decode_timestamp' do
       #   it 'decodes the timestamp from a 64 byte big endian integer and returns a Time object' do
-      #     Basic.decode_timestamp("\x00\x00\x00\x00\x00\x0009").should == Time.at(12345)
+      #     expect(Basic.decode_timestamp("\x00\x00\x00\x00\x00\x0009")).to eq(Time.at(12345))
       #   end
       # end
       
       describe '.encode_headers' do
         it 'encodes the headers as a table' do
-          Basic.encode_headers(:hello => 'world').last.should == "\x00\x00\x00\x10\x05helloS\x00\x00\x00\x05world"
+          expect(Basic.encode_headers(:hello => 'world').last).to eq("\x00\x00\x00\x10\x05helloS\x00\x00\x00\x05world")
         end
       end
       
       # describe '.decode_headers' do
       #   it 'decodes the headers from a table' do
-      #     Basic.decode_headers("\x00\x00\x00\x10\x05helloS\x00\x00\x00\x05world").should == {'hello' => 'world'}
+      #     expect(Basic.decode_headers("\x00\x00\x00\x10\x05helloS\x00\x00\x00\x05world")).to eq({'hello' => 'world'})
       #   end
       # end
       
       describe '.encode_properties' do
         it 'packs the parameters into a byte array using the other encode_* methods' do
           result = Basic.encode_properties(10, {:priority => 0, :delivery_mode => 2, :content_type => 'application/octet-stream'})
-          result.should == "\x00<\x00\x00\x00\x00\x00\x00\x00\x00\x00\x0a\x98\x00\x18application/octet-stream\x02\x00"
+          expect(result).to eq("\x00<\x00\x00\x00\x00\x00\x00\x00\x00\x00\x0a\x98\x00\x18application/octet-stream\x02\x00")
         end
       end
       
       describe '.decode_properties' do
         it 'unpacks the properties from a byte array using the decode_* methods' do
           result = Basic.decode_properties("\x98@\x18application/octet-stream\x02\x00\x00\x00\x00\x00\x00\x00\x00{")
-          result.should == {:priority => 0, :delivery_mode => 2, :content_type => 'application/octet-stream', :timestamp => Time.at(123)}
+          expect(result).to eq({:priority => 0, :delivery_mode => 2, :content_type => 'application/octet-stream', :timestamp => Time.at(123)})
         end
 
         it 'unpacks the properties from a byte array using the decode_* methods, including a table' do
           result = Basic.decode_properties("\xB8@\x18application/octet-stream\x00\x00\x00\x10\x05helloS\x00\x00\x00\x05world\x02\x00\x00\x00\x00\x00\x00\x00\x00{")
-          result.should == {:priority => 0, :delivery_mode => 2, :content_type => 'application/octet-stream', :timestamp => Time.at(123), :headers => {'hello' => 'world'}}
+          expect(result).to eq({:priority => 0, :delivery_mode => 2, :content_type => 'application/octet-stream', :timestamp => Time.at(123), :headers => {'hello' => 'world'}})
         end
       end
       
       %w(content_type content_encoding correlation_id reply_to expiration message_id type user_id app_id cluster_id).each do |method|
         describe ".encode_#{method}" do
           it 'encodes the parameter as a Pascal string' do
-            Basic.send("encode_#{method}", 'hello world').last.should == "\x0bhello world"
+            expect(Basic.send("encode_#{method}", 'hello world').last).to eq("\x0bhello world")
           end
         end
 
         # describe ".decode_#{method}" do
         #   it 'returns the string' do
         #     # the length has been stripped in .decode_properties
-        #     Basic.send("decode_#{method}", 'hello world').should == 'hello world'
+        #     expect(Basic.send("decode_#{method}", 'hello world')).to eq('hello world')
         #   end
         # end
       end
@@ -67,13 +67,13 @@ module AMQ
       %w(delivery_mode priority).each do |method|
         describe ".encode_#{method}" do
           it 'encodes the parameter as a char' do
-            Basic.send("encode_#{method}", 10).last.should == "\x0a"
+            expect(Basic.send("encode_#{method}", 10).last).to eq("\x0a")
           end
         end
 
         # describe ".decode_#{method}" do
         #   it 'decodes the value from a char' do
-        #     Basic.send("decode_#{method}", "\x10").should == 16
+        #     expect(Basic.send("decode_#{method}", "\x10")).to eq(16)
         #   end
         # end
       end
@@ -88,8 +88,8 @@ module AMQ
             prefetch_count = 5
             global = false
             method_frame = Qos.encode(channel, prefetch_size, prefetch_count, global)
-            method_frame.payload.should == "\x00<\x00\n\x00\x00\x00\x03\x00\x05\x00"
-            method_frame.channel.should == 1
+            expect(method_frame.payload).to eq("\x00<\x00\n\x00\x00\x00\x03\x00\x05\x00")
+            expect(method_frame.channel).to eq(1)
           end
         end
       end
@@ -111,8 +111,8 @@ module AMQ
             nowait = false
             arguments = nil
             method_frame = Consume.encode(channel, queue, consumer_tag, no_local, no_ack, exclusive, nowait, arguments)
-            method_frame.payload.should == "\x00<\x00\x14\x00\x00\x03foo\x02me\x04\x00\x00\x00\x00"
-            method_frame.channel.should == 1
+            expect(method_frame.payload).to eq("\x00<\x00\x14\x00\x00\x03foo\x02me\x04\x00\x00\x00\x00")
+            expect(method_frame.channel).to eq(1)
           end
         end
       end
@@ -123,7 +123,7 @@ module AMQ
             ConsumeOk.decode("\x03foo")
           end
           
-          its(:consumer_tag) { should == 'foo' }
+          its(:consumer_tag) { should eq('foo') }
         end
       end
 
@@ -134,8 +134,8 @@ module AMQ
             consumer_tag = 'foo'
             nowait = true
             method_frame = Cancel.encode(channel, consumer_tag, nowait)
-            method_frame.payload.should == "\x00<\x00\x1E\x03foo\x01"
-            method_frame.channel.should == 1
+            expect(method_frame.payload).to eq("\x00<\x00\x1E\x03foo\x01")
+            expect(method_frame.channel).to eq(1)
           end
         end
         
@@ -144,7 +144,7 @@ module AMQ
             CancelOk.decode("\x03foo\x01")            
           end
 
-          its(:consumer_tag) { should == 'foo' }
+          its(:consumer_tag) { should eq('foo') }
         end
       end
 
@@ -154,7 +154,7 @@ module AMQ
             CancelOk.decode("\x03foo")
           end
           
-          its(:consumer_tag) { should == 'foo' }
+          its(:consumer_tag) { should eq('foo') }
         end
       end
 
@@ -170,13 +170,13 @@ module AMQ
             immediate = true
             frame_size = 512
             method_frames = Publish.encode(channel, payload, user_headers, exchange, routing_key, mandatory, immediate, frame_size)
-            method_frames[0].payload.should == "\x00<\x00(\x00\x00\x03foo\x03xyz\x02"
-            method_frames[1].payload.should == "\x00<\x00\x00\x00\x00\x00\x00\x00\x00\x00\f\x88\x00\x18application/octet-stream\x00"
-            method_frames[2].payload.should == "Hello World!"
-            method_frames[0].channel.should == 1
-            method_frames[1].channel.should == 1
-            method_frames[2].channel.should == 1
-            method_frames.should have(3).items
+            expect(method_frames[0].payload).to eq("\x00<\x00(\x00\x00\x03foo\x03xyz\x02")
+            expect(method_frames[1].payload).to eq("\x00<\x00\x00\x00\x00\x00\x00\x00\x00\x00\f\x88\x00\x18application/octet-stream\x00")
+            expect(method_frames[2].payload).to eq("Hello World!")
+            expect(method_frames[0].channel).to eq(1)
+            expect(method_frames[1].channel).to eq(1)
+            expect(method_frames[2].channel).to eq(1)
+            expect(method_frames.size).to eq(3)
           end
         end
       end
@@ -187,10 +187,10 @@ module AMQ
             Return.decode("\x019\fNO_CONSUMERS\namq.fanout\x00")
           end
           
-          its(:reply_code) { should == 313 }
-          its(:reply_text) { should == 'NO_CONSUMERS' }
-          its(:exchange) { should == 'amq.fanout' }
-          its(:routing_key) { should == '' }
+          its(:reply_code) { should eq(313) }
+          its(:reply_text) { should eq('NO_CONSUMERS') }
+          its(:exchange) { should eq('amq.fanout') }
+          its(:routing_key) { should eq('') }
         end
       end
 
@@ -200,11 +200,11 @@ module AMQ
             Deliver.decode("\e-1300560114000-445586772970\x00\x00\x00\x00\x00\x00\x00c\x00\namq.fanout\x00")
           end
           
-          its(:consumer_tag) { should == '-1300560114000-445586772970' }
-          its(:delivery_tag) { should == 99 }
-          its(:redelivered) { should == false }
-          its(:exchange) { should == 'amq.fanout' }
-          its(:routing_key) { should == '' }
+          its(:consumer_tag) { should eq('-1300560114000-445586772970') }
+          its(:delivery_tag) { should eq(99) }
+          its(:redelivered) { should eq(false) }
+          its(:exchange) { should eq('amq.fanout') }
+          its(:routing_key) { should eq('') }
         end
       end
       
@@ -215,8 +215,8 @@ module AMQ
             queue = 'foo'
             no_ack = true
             method_frame = Get.encode(channel, queue, no_ack)
-            method_frame.payload.should == "\x00\x3c\x00\x46\x00\x00\x03foo\x01"
-            method_frame.channel.should == 1
+            expect(method_frame.payload).to eq("\x00\x3c\x00\x46\x00\x00\x03foo\x01")
+            expect(method_frame.channel).to eq(1)
           end
         end
       end
@@ -227,11 +227,11 @@ module AMQ
             GetOk.decode("\x00\x00\x00\x00\x00\x00\x00\x06\x00\namq.fanout\x00\x00\x00\x00^")
           end
           
-          its(:delivery_tag) { should == 6 }
-          its(:redelivered) { should == false }
-          its(:exchange) { should == 'amq.fanout' }
-          its(:routing_key) { should == '' }
-          its(:message_count) { should == 94 }
+          its(:delivery_tag) { should eq(6) }
+          its(:redelivered) { should eq(false) }
+          its(:exchange) { should eq('amq.fanout') }
+          its(:routing_key) { should eq('') }
+          its(:message_count) { should eq(94) }
         end
       end
       
@@ -241,7 +241,7 @@ module AMQ
             GetEmpty.decode("\x03foo")
           end
           
-          its(:cluster_id) { should == 'foo' }
+          its(:cluster_id) { should eq('foo') }
         end
       end
 
@@ -252,8 +252,8 @@ module AMQ
             delivery_tag = 6
             multiple = false
             method_frame = Ack.encode(channel, delivery_tag, multiple)
-            method_frame.payload.should == "\x00<\x00P\x00\x00\x00\x00\x00\x00\x00\x06\x00"
-            method_frame.channel.should == 1
+            expect(method_frame.payload).to eq("\x00<\x00P\x00\x00\x00\x00\x00\x00\x00\x06\x00")
+            expect(method_frame.channel).to eq(1)
           end
         end
       end
@@ -265,8 +265,8 @@ module AMQ
             delivery_tag = 8
             requeue = true
             method_frame = Reject.encode(channel, delivery_tag, requeue)
-            method_frame.payload.should == "\x00<\x00Z\x00\x00\x00\x00\x00\x00\x00\x08\x01"
-            method_frame.channel.should == 1
+            expect(method_frame.payload).to eq("\x00<\x00Z\x00\x00\x00\x00\x00\x00\x00\x08\x01")
+            expect(method_frame.channel).to eq(1)
           end
         end
       end
@@ -277,8 +277,8 @@ module AMQ
             channel = 1
             requeue = true
             method_frame = RecoverAsync.encode(channel, requeue)
-            method_frame.payload.should == "\x00<\x00d\x01"
-            method_frame.channel.should == 1
+            expect(method_frame.payload).to eq("\x00<\x00d\x01")
+            expect(method_frame.channel).to eq(1)
           end
         end
       end
@@ -289,8 +289,8 @@ module AMQ
             channel = 1
             requeue = true
             method_frame = Recover.encode(channel, requeue)
-            method_frame.payload.should == "\x00<\x00n\x01"
-            method_frame.channel.should == 1
+            expect(method_frame.payload).to eq("\x00<\x00n\x01")
+            expect(method_frame.channel).to eq(1)
           end
         end
       end
@@ -306,9 +306,9 @@ module AMQ
             Nack.decode("\x00\x00\x00\x00\x00\x00\x00\x09\x03")
           end
           
-          its(:delivery_tag) { should == 9 }
-          its(:multiple) { should == true }
-          its(:requeue) { should == true }
+          its(:delivery_tag) { should eq(9) }
+          its(:multiple) { should eq(true) }
+          its(:requeue) { should eq(true) }
         end
         
         describe '.encode' do
@@ -318,8 +318,8 @@ module AMQ
             multiple = false
             requeue = true
             method_frame = Nack.encode(channel, delivery_tag, multiple, requeue)
-            method_frame.payload.should == "\x00<\x00x\x00\x00\x00\x00\x00\x00\x00\x0a\x02"
-            method_frame.channel.should == 1
+            expect(method_frame.payload).to eq("\x00<\x00x\x00\x00\x00\x00\x00\x00\x00\x0a\x02")
+            expect(method_frame.channel).to eq(1)
           end
         end
       end

--- a/spec/amq/protocol/blank_body_encoding_spec.rb
+++ b/spec/amq/protocol/blank_body_encoding_spec.rb
@@ -5,10 +5,10 @@ require File.expand_path('../../../spec_helper', __FILE__)
 
 describe AMQ::Protocol::Method, ".encode_body" do
   it "encodes 1-byte long payload as exactly 1 body frame" do
-    described_class.encode_body('1', 1, 65536).size.should == 1
+    expect(described_class.encode_body('1', 1, 65536).size).to eq(1)
   end
 
   it "encodes 0-byte long (blank) payload as exactly 0 body frame" do
-    described_class.encode_body('', 1, 65536).size.should == 0
+    expect(described_class.encode_body('', 1, 65536).size).to eq(0)
   end
 end

--- a/spec/amq/protocol/channel_spec.rb
+++ b/spec/amq/protocol/channel_spec.rb
@@ -119,9 +119,9 @@ module AMQ
         describe '.encode' do
           it 'encodes the parameters into a MethodFrame' do
             channel = 1
-            method_frame = CloseOk.encode(1)
+            method_frame = CloseOk.encode(channel)
             expect(method_frame.payload).to eq("\x00\x14\x00\x29")
-            expect(method_frame.channel).to eq(1)
+            expect(method_frame.channel).to eq(channel)
           end
         end
       end

--- a/spec/amq/protocol/channel_spec.rb
+++ b/spec/amq/protocol/channel_spec.rb
@@ -12,8 +12,8 @@ module AMQ
             channel = 1
             out_of_band = ''
             method_frame = Open.encode(channel, out_of_band)
-            method_frame.payload.should == "\x00\x14\x00\n\x00"
-            method_frame.channel.should == 1
+            expect(method_frame.payload).to eq("\x00\x14\x00\n\x00")
+            expect(method_frame.channel).to eq(1)
           end
         end
       end
@@ -24,7 +24,7 @@ module AMQ
             OpenOk.decode("\x00\x00\x00\x03foo")
           end
 
-          its(:channel_id) { should == 'foo' }
+          its(:channel_id) { should eq('foo') }
         end
       end
 
@@ -34,7 +34,7 @@ module AMQ
             Flow.decode("\x01")
           end
 
-          its(:active) { should be_true }
+          its(:active) { should be_truthy }
         end
 
         describe '.encode' do
@@ -42,8 +42,8 @@ module AMQ
             channel = 1
             active = true
             method_frame = Flow.encode(channel, active)
-            method_frame.payload.should == "\x00\x14\x00\x14\x01"
-            method_frame.channel.should == 1
+            expect(method_frame.payload).to eq("\x00\x14\x00\x14\x01")
+            expect(method_frame.channel).to eq(1)
           end
         end
       end
@@ -54,7 +54,7 @@ module AMQ
             FlowOk.decode("\x00")
           end
 
-          its(:active) { should be_false }
+          its(:active) { should be_falsey }
         end
 
         describe '.encode' do
@@ -62,8 +62,8 @@ module AMQ
             channel = 1
             active = true
             method_frame = FlowOk.encode(channel, active)
-            method_frame.payload.should == "\x00\x14\x00\x15\x01"
-            method_frame.channel.should == 1
+            expect(method_frame.payload).to eq("\x00\x14\x00\x15\x01")
+            expect(method_frame.channel).to eq(1)
           end
         end
       end
@@ -75,10 +75,10 @@ module AMQ
               Close.decode("\x00\xc8\x07KTHXBAI\x00\x05\x00\x06")
             end
 
-            its(:reply_code) { should == 200 }
-            its(:reply_text) { should == 'KTHXBAI' }
-            its(:class_id) { should == 5 }
-            its(:method_id) { should == 6 }
+            its(:reply_code) { should eq(200) }
+            its(:reply_text) { should eq('KTHXBAI') }
+            its(:class_id) { should eq(5) }
+            its(:method_id) { should eq(6) }
           end
 
 
@@ -88,10 +88,10 @@ module AMQ
               Close.decode(raw)
             end
 
-            its(:reply_code) { should == 404 }
-            its(:reply_text) { should == %q{NOT_FOUND - no binding 123456789012345678901234567890123 between exchange 'amq.topic' in vhost '/' and queue 'test' in vhost '/'} }
-            its(:class_id) { should == 50 }
-            its(:method_id) { should == 50 }
+            its(:reply_code) { should eq(404) }
+            its(:reply_text) { should eq(%q{NOT_FOUND - no binding 123456789012345678901234567890123 between exchange 'amq.topic' in vhost '/' and queue 'test' in vhost '/'}) }
+            its(:class_id) { should eq(50) }
+            its(:method_id) { should eq(50) }
           end
 
           context 'with an error code' do
@@ -109,8 +109,8 @@ module AMQ
             class_id = 0
             method_id = 0
             method_frame = Close.encode(channel, reply_code, reply_text, class_id, method_id)
-            method_frame.payload.should == "\x00\x14\x00(\x02\x1c\x0fNOT_IMPLEMENTED\x00\x00\x00\x00"
-            method_frame.channel.should == 1
+            expect(method_frame.payload).to eq("\x00\x14\x00(\x02\x1c\x0fNOT_IMPLEMENTED\x00\x00\x00\x00")
+            expect(method_frame.channel).to eq(1)
           end
         end
       end
@@ -120,8 +120,8 @@ module AMQ
           it 'encodes the parameters into a MethodFrame' do
             channel = 1
             method_frame = CloseOk.encode(1)
-            method_frame.payload.should == "\x00\x14\x00\x29"
-            method_frame.channel.should == 1
+            expect(method_frame.payload).to eq("\x00\x14\x00\x29")
+            expect(method_frame.channel).to eq(1)
           end
         end
       end

--- a/spec/amq/protocol/confirm_spec.rb
+++ b/spec/amq/protocol/confirm_spec.rb
@@ -12,7 +12,7 @@ module AMQ
             Select.decode("\x01")
           end
           
-          its(:nowait) { should be_true }
+          its(:nowait) { should be_truthy }
         end
         
         describe '.encode' do
@@ -20,8 +20,8 @@ module AMQ
             channel = 1
             nowait = true
             method_frame = Select.encode(channel, nowait)
-            method_frame.payload.should == "\x00U\x00\n\x01"
-            method_frame.channel.should == 1
+            expect(method_frame.payload).to eq("\x00U\x00\n\x01")
+            expect(method_frame.channel).to eq(1)
           end
         end
       end
@@ -34,8 +34,8 @@ module AMQ
           it 'encodes the parameters into a MethodFrame' do
             channel = 1
             method_frame = SelectOk.encode(channel)
-            method_frame.payload.should == "\000U\000\v"
-            method_frame.channel.should == 1
+            expect(method_frame.payload).to eq("\000U\000\v")
+            expect(method_frame.channel).to eq(1)
           end
         end
       end

--- a/spec/amq/protocol/connection_spec.rb
+++ b/spec/amq/protocol/connection_spec.rb
@@ -29,13 +29,13 @@ module AMQ
             locale = 'en_GB'
             method_frame = StartOk.encode(client_properties, mechanism, response, locale)
             # the order of the table parts isn't deterministic in Ruby 1.8
-            method_frame.payload[0, 8].should == "\x00\n\x00\v\x00\x00\x00x"
-            method_frame.payload.should include("\bplatformS\x00\x00\x00\nRuby 1.9.2")
-            method_frame.payload.should include("\aproductS\x00\x00\x00\nAMQ Client")
-            method_frame.payload.should include("\vinformationS\x00\x00\x00&http://github.com/ruby-amqp/amq-client")
-            method_frame.payload.should include("\aversionS\x00\x00\x00\x050.2.0")
-            method_frame.payload[-28, 28].should == "\x05PLAIN\x00\x00\x00\f\x00guest\x00guest\x05en_GB"
-            method_frame.payload.length.should == 156
+            expect(method_frame.payload[0, 8]).to eq("\x00\n\x00\v\x00\x00\x00x")
+            expect(method_frame.payload).to include("\bplatformS\x00\x00\x00\nRuby 1.9.2")
+            expect(method_frame.payload).to include("\aproductS\x00\x00\x00\nAMQ Client")
+            expect(method_frame.payload).to include("\vinformationS\x00\x00\x00&http://github.com/ruby-amqp/amq-client")
+            expect(method_frame.payload).to include("\aversionS\x00\x00\x00\x050.2.0")
+            expect(method_frame.payload[-28, 28]).to eq("\x05PLAIN\x00\x00\x00\f\x00guest\x00guest\x05en_GB")
+            expect(method_frame.payload.length).to eq(156)
           end
         end
       end
@@ -46,7 +46,7 @@ module AMQ
             Secure.decode("\x00\x00\x00\x03foo")
           end
           
-          its(:challenge) { should == 'foo' }
+          its(:challenge) { should eq('foo') }
         end
       end
     
@@ -55,7 +55,7 @@ module AMQ
           it 'encodes the parameters as a MethodFrame' do
             response = 'bar'
             method_frame = SecureOk.encode(response)
-            method_frame.payload.should == "\x00\x0a\x00\x15\x00\x00\x00\x03bar"
+            expect(method_frame.payload).to eq("\x00\x0a\x00\x15\x00\x00\x00\x03bar")
           end
         end
       end
@@ -66,9 +66,9 @@ module AMQ
             Tune.decode("\x00\x00\x00\x02\x00\x00\x00\x00")
           end
 
-          its(:channel_max) { should == 0 }
-          its(:frame_max) { should == 131072 }
-          its(:heartbeat) { should == 0}
+          its(:channel_max) { should eq(0) }
+          its(:frame_max) { should eq(131072) }
+          its(:heartbeat) { should eq(0) }
         end
       end
 
@@ -79,7 +79,7 @@ module AMQ
             frame_max = 65536
             heartbeat = 1
             method_frame = TuneOk.encode(channel_max, frame_max, heartbeat)
-            method_frame.payload.should == "\x00\n\x00\x1F\x00\x00\x00\x01\x00\x00\x00\x01"
+            expect(method_frame.payload).to eq("\x00\n\x00\x1F\x00\x00\x00\x01\x00\x00\x00\x01")
           end
         end
       end
@@ -89,7 +89,7 @@ module AMQ
           it 'encodes the parameters into a MethodFrame' do
             vhost = '/test'
             method_frame = Open.encode(vhost)
-            method_frame.payload.should == "\x00\n\x00(\x05/test\x00\x00"
+            expect(method_frame.payload).to eq("\x00\n\x00(\x05/test\x00\x00")
           end
         end
       end
@@ -100,7 +100,7 @@ module AMQ
             OpenOk.decode("\x00")
           end
           
-          its(:known_hosts) { should == '' }
+          its(:known_hosts) { should eq('') }
         end
       end
       
@@ -111,10 +111,10 @@ module AMQ
               Close.decode("\x00\xc8\x07KTHXBAI\x00\x05\x00\x06")
             end
           
-            its(:reply_code) { should == 200 }
-            its(:reply_text) { should == 'KTHXBAI' }
-            its(:class_id) { should == 5 }
-            its(:method_id) { should == 6 }
+            its(:reply_code) { should eq(200) }
+            its(:reply_text) { should eq('KTHXBAI') }
+            its(:class_id) { should eq(5) }
+            its(:method_id) { should eq(6) }
           end
           
           context 'with an error code' do
@@ -131,7 +131,7 @@ module AMQ
             class_id = 0
             method_id = 0
             method_frame = Close.encode(reply_code, reply_text, class_id, method_id)
-            method_frame.payload.should == "\x00\x0a\x002\x02\x1c\x0fNOT_IMPLEMENTED\x00\x00\x00\x00"
+            expect(method_frame.payload).to eq("\x00\x0a\x002\x02\x1c\x0fNOT_IMPLEMENTED\x00\x00\x00\x00")
           end
         end
       end
@@ -140,7 +140,7 @@ module AMQ
         describe '.encode' do
           it 'encodes a MethodFrame' do
             method_frame = CloseOk.encode
-            method_frame.payload.should == "\x00\n\x003"
+            expect(method_frame.payload).to eq("\x00\n\x003")
           end
         end
       end

--- a/spec/amq/protocol/constants_spec.rb
+++ b/spec/amq/protocol/constants_spec.rb
@@ -2,13 +2,13 @@
 
 require File.expand_path('../../../spec_helper', __FILE__)
 
-describe "(Some)", AMQ::Protocol, "constants" do
+describe "(Some) AMQ::Protocol constants" do
   it "include regular port" do
-    AMQ::Protocol::DEFAULT_PORT.should == 5672
+    expect(AMQ::Protocol::DEFAULT_PORT).to eq(5672)
   end
 
   it "provides TLS/SSL port" do
-    AMQ::Protocol::TLS_PORT.should == 5671
-    AMQ::Protocol::SSL_PORT.should == 5671
+    expect(AMQ::Protocol::TLS_PORT).to eq(5671)
+    expect(AMQ::Protocol::SSL_PORT).to eq(5671)
   end
 end

--- a/spec/amq/protocol/exchange_spec.rb
+++ b/spec/amq/protocol/exchange_spec.rb
@@ -19,8 +19,8 @@ module AMQ
             nowait = false
             arguments = nil
             method_frame = Declare.encode(channel, exchange, type, passive, durable, auto_delete, internal, nowait, arguments)
-            method_frame.payload.should == "\x00(\x00\n\x00\x00\x1Famqclient.adapters.em.exchange1\x06fanout\x00\x00\x00\x00\x00"
-            method_frame.channel.should == 1
+            expect(method_frame.payload).to eq("\x00(\x00\n\x00\x00\x1Famqclient.adapters.em.exchange1\x06fanout\x00\x00\x00\x00\x00")
+            expect(method_frame.channel).to eq(1)
           end
         end
       end
@@ -38,8 +38,8 @@ module AMQ
             nowait = false
             arguments = nil
             method_frame = Declare.encode(channel, exchange, type, passive, durable, auto_delete, internal, nowait, arguments)
-            method_frame.payload.should == "\x00(\x00\n\x00\x00\texchange2\x06fanout\x00\x00\x00\x00\x00"
-            method_frame.channel.should == 1
+            expect(method_frame.payload).to eq("\x00(\x00\n\x00\x00\texchange2\x06fanout\x00\x00\x00\x00\x00")
+            expect(method_frame.channel).to eq(1)
           end
         end
       end
@@ -52,8 +52,8 @@ module AMQ
             if_unused = false
             nowait = false
             method_frame = Delete.encode(channel, exchange, if_unused, nowait)
-            method_frame.payload.should == "\x00(\x00\x14\x00\x00\x1Eamqclient.adapters.em.exchange\x00"
-            method_frame.channel.should == 1
+            expect(method_frame.payload).to eq("\x00(\x00\x14\x00\x00\x1Eamqclient.adapters.em.exchange\x00")
+            expect(method_frame.channel).to eq(1)
           end
         end
       end
@@ -73,8 +73,8 @@ module AMQ
             nowait = false
             arguments = nil
             method_frame = Bind.encode(channel, destination, source, routing_key, nowait, arguments)
-            method_frame.payload.should == "\x00(\x00\x1E\x00\x00\x03foo\x03bar\x03xyz\x00\x00\x00\x00\x00"
-            method_frame.channel.should == 1
+            expect(method_frame.payload).to eq("\x00(\x00\x1E\x00\x00\x03foo\x03bar\x03xyz\x00\x00\x00\x00\x00")
+            expect(method_frame.channel).to eq(1)
           end
         end
       end
@@ -94,8 +94,8 @@ module AMQ
             nowait = false
             arguments = nil
             method_frame = Unbind.encode(channel, destination, source, routing_key, nowait, arguments)
-            method_frame.payload.should == "\x00(\x00(\x00\x00\x03foo\x03bar\x03xyz\x00\x00\x00\x00\x00"
-            method_frame.channel.should == 1
+            expect(method_frame.payload).to eq("\x00(\x00(\x00\x00\x03foo\x03bar\x03xyz\x00\x00\x00\x00\x00")
+            expect(method_frame.channel).to eq(1)
           end
         end
       end

--- a/spec/amq/protocol/frame_spec.rb
+++ b/spec/amq/protocol/frame_spec.rb
@@ -1,4 +1,4 @@
-# encoding: binary
+# encoding: utf-8
 
 require File.expand_path('../../../spec_helper', __FILE__)
 
@@ -8,7 +8,7 @@ module AMQ
     describe Frame do
       describe ".encode" do
         it "should raise FrameTypeError if type isn't one of: [:method, :header, :body, :heartbeat]" do
-          lambda { Frame.encode(nil, "", 0) }.should raise_error(FrameTypeError)
+          expect { Frame.encode(nil, "", 0) }.to raise_error(FrameTypeError)
         end
 
         it "should raise FrameTypeError if type isn't valid (when type is a symbol)" do
@@ -20,35 +20,35 @@ module AMQ
         end
 
         it "should raise RuntimeError if channel isn't 0 or an integer in range 1..65535" do
-          lambda { Frame.encode(:method, "", -1) }.should raise_error(RuntimeError, /^Channel has to be 0 or an integer in range 1\.\.65535/)
-          lambda { Frame.encode(:method, "", 65536) }.should raise_error(RuntimeError, /^Channel has to be 0 or an integer in range 1\.\.65535/)
-          lambda { Frame.encode(:method, "", 65535) }.should_not raise_error(RuntimeError, /^Channel has to be 0 or an integer in range 1\.\.65535/)
-          lambda { Frame.encode(:method, "", 0) }.should_not raise_error(RuntimeError, /^Channel has to be 0 or an integer in range 1\.\.65535/)
-          lambda { Frame.encode(:method, "", 1) }.should_not raise_error(RuntimeError, /^Channel has to be 0 or an integer in range 1\.\.65535/)
+          expect { Frame.encode(:method, "", -1) }.to raise_error(RuntimeError, /^Channel has to be 0 or an integer in range 1\.\.65535/)
+          expect { Frame.encode(:method, "", 65536) }.to raise_error(RuntimeError, /^Channel has to be 0 or an integer in range 1\.\.65535/)
+          expect { Frame.encode(:method, "", 65535) }.not_to raise_error
+          expect { Frame.encode(:method, "", 0) }.not_to raise_error
+          expect { Frame.encode(:method, "", 1) }.not_to raise_error
         end
 
         it "should raise RuntimeError if payload is nil" do
-          lambda { Frame.encode(:method, nil, 0) }.should raise_error(RuntimeError, "Payload can't be nil")
+          expect { Frame.encode(:method, nil, 0) }.to raise_error(RuntimeError, "Payload can't be nil")
         end
 
         it "should encode type" do
-          Frame.encode(:body, "", 0).unpack("c").first.should eql(3)
+          expect(Frame.encode(:body, "", 0).unpack("c").first).to eql(3)
         end
 
         it "should encode channel" do
-          Frame.encode(:body, "", 12).unpack("cn").last.should eql(12)
+          expect(Frame.encode(:body, "", 12).unpack("cn").last).to eql(12)
         end
 
         it "should encode size" do
-          Frame.encode(:body, "test", 12).unpack("cnN").last.should eql(4)
+          expect(Frame.encode(:body, "test", 12).unpack("cnN").last).to eql(4)
         end
 
         it "should include payload" do
-          Frame.encode(:body, "test", 12)[7..-2].should eql("test")
+          expect(Frame.encode(:body, "test", 12)[7..-2]).to eql("test")
         end
 
         it "should include final octet" do
-          Frame.encode(:body, "test", 12).should =~ /\xCE$/
+          expect(Frame.encode(:body, "test", 12).each_byte.to_a.last).to eq("CE".hex)
         end
 
         it "should encode unicode strings" do
@@ -76,20 +76,20 @@ module AMQ
         subject { HeaderFrame.new("\x00<\x00\x00\x00\x00\x00\x00\x00\x00\x00\n\x98\x00\x18application/octet-stream\x02\x00", nil) }
 
         it "should decode body_size from payload" do
-          subject.body_size.should == 10
+          expect(subject.body_size).to eq(10)
         end
 
         it "should decode klass_id from payload" do
-          subject.klass_id.should == 60
+          expect(subject.klass_id).to eq(60)
         end
 
         it "should decode weight from payload" do
-          subject.weight.should == 0
+          expect(subject.weight).to eq(0)
         end
 
         it "should decode properties from payload" do
-          subject.properties[:delivery_mode].should == 2
-          subject.properties[:priority].should == 0
+          expect(subject.properties[:delivery_mode]).to eq(2)
+          expect(subject.properties[:priority]).to eq(0)
         end
       end
     end

--- a/spec/amq/protocol/method_spec.rb
+++ b/spec/amq/protocol/method_spec.rb
@@ -10,8 +10,8 @@ module AMQ
         it 'splits user defined headers into properties and headers' do
           input = {:delivery_mode => 2, :content_type => 'application/octet-stream', :foo => 'bar'}
           properties, headers = Method.split_headers(input)
-          properties.should == {:delivery_mode => 2, :content_type => 'application/octet-stream'}
-          headers.should == {:foo => 'bar'}
+          expect(properties).to eq({:delivery_mode => 2, :content_type => 'application/octet-stream'})
+          expect(headers).to eq({:foo => 'bar'})
         end
       end
       
@@ -19,9 +19,9 @@ module AMQ
         context 'when the body fits in a single frame' do
           it 'encodes a body into a BodyFrame' do
             body_frames = Method.encode_body('Hello world', 1, 131072)
-            body_frames.first.payload.should == 'Hello world'
-            body_frames.first.channel.should == 1
-            body_frames.should have(1).item
+            expect(body_frames.first.payload).to eq('Hello world')
+            expect(body_frames.first.channel).to eq(1)
+            expect(body_frames.size).to eq(1)
           end
         end
 
@@ -31,15 +31,15 @@ module AMQ
             frame_size = 100
             expected_payload_size = 92
             body_frames = Method.encode_body(lipsum, 1, frame_size)
-            body_frames.map(&:payload).should == lipsum.split('').each_slice(expected_payload_size).map(&:join)
+            expect(body_frames.map(&:payload)).to eq(lipsum.split('').each_slice(expected_payload_size).map(&:join))
           end
         end
 
         context 'when the body fits perfectly in a single frame' do
           it 'encodes a body into a single BodyFrame' do
             body_frames = Method.encode_body('*' * 131064, 1, 131072)
-            body_frames.first.payload.should == '*' * 131064
-            body_frames.should have(1).item
+            expect(body_frames.first.payload).to eq('*' * 131064)
+            expect(body_frames.size).to eq(1)
           end
         end
       end

--- a/spec/amq/protocol/queue_spec.rb
+++ b/spec/amq/protocol/queue_spec.rb
@@ -18,8 +18,8 @@ module AMQ
             nowait = false
             arguments = nil
             method_frame = Declare.encode(channel, queue, passive, durable, exclusive, auto_delete, nowait, arguments)
-            method_frame.payload.should == "\x002\x00\n\x00\x00\vhello.world\x0E\x00\x00\x00\x00"
-            method_frame.channel.should == 1
+            expect(method_frame.payload).to eq("\x002\x00\n\x00\x00\vhello.world\x0E\x00\x00\x00\x00")
+            expect(method_frame.channel).to eq(1)
           end
         end
       end
@@ -30,9 +30,9 @@ module AMQ
             DeclareOk.decode(" amq.gen-KduGSqQrpeUo1otnU0TWSA==\x00\x00\x00\x00\x00\x00\x00\x00")
           end
           
-          its(:queue) { should == 'amq.gen-KduGSqQrpeUo1otnU0TWSA==' }
-          its(:message_count) { should == 0 }
-          its(:consumer_count) { should == 0 }
+          its(:queue) { should eq('amq.gen-KduGSqQrpeUo1otnU0TWSA==') }
+          its(:message_count) { should eq(0) }
+          its(:consumer_count) { should eq(0) }
         end
       end
 
@@ -46,8 +46,8 @@ module AMQ
             nowait = false
             arguments = nil
             method_frame = Bind.encode(channel, queue, exchange, routing_key, nowait, arguments)
-            method_frame.payload.should == "\x002\x00\x14\x00\x00\vhello.world\afoo.bar\x03xyz\x00\x00\x00\x00\x00"
-            method_frame.channel.should == 1
+            expect(method_frame.payload).to eq("\x002\x00\x14\x00\x00\vhello.world\afoo.bar\x03xyz\x00\x00\x00\x00\x00")
+            expect(method_frame.channel).to eq(1)
           end
         end
       end
@@ -64,8 +64,8 @@ module AMQ
             queue = 'hello.world'
             nowait = false
             method_frame = Purge.encode(channel, queue, nowait)
-            method_frame.payload.should == "\x002\x00\x1E\x00\x00\vhello.world\x00"
-            method_frame.channel.should == 1
+            expect(method_frame.payload).to eq("\x002\x00\x1E\x00\x00\vhello.world\x00")
+            expect(method_frame.channel).to eq(1)
           end
         end
       end
@@ -76,7 +76,7 @@ module AMQ
             PurgeOk.decode("\x00\x00\x00\x02")
           end
           
-          its(:message_count) { should == 2 }
+          its(:message_count) { should eq(2) }
         end
       end
 
@@ -89,8 +89,8 @@ module AMQ
             if_empty = false
             nowait = false
             method_frame = Delete.encode(channel, queue, if_unused, if_empty, nowait)
-            method_frame.payload.should == "\x002\x00(\x00\x00\vhello.world\x00"
-            method_frame.channel.should == 1
+            expect(method_frame.payload).to eq("\x002\x00(\x00\x00\vhello.world\x00")
+            expect(method_frame.channel).to eq(1)
           end
         end
       end
@@ -101,7 +101,7 @@ module AMQ
             DeleteOk.decode("\x00\x00\x00\x02")
           end
           
-          its(:message_count) { should == 2 }
+          its(:message_count) { should eq(2) }
         end
       end
 
@@ -114,8 +114,8 @@ module AMQ
             routing_key = 'xyz'
             arguments = nil
             method_frame = Unbind.encode(channel, queue, exchange, routing_key, arguments)
-            method_frame.payload.should == "\x002\x002\x00\x00\vhello.world\afoo.bar\x03xyz\x00\x00\x00\x00"
-            method_frame.channel.should == 1
+            expect(method_frame.payload).to eq("\x002\x002\x00\x00\vhello.world\afoo.bar\x03xyz\x00\x00\x00\x00")
+            expect(method_frame.channel).to eq(1)
           end
         end
       end

--- a/spec/amq/protocol/table_spec.rb
+++ b/spec/amq/protocol/table_spec.rb
@@ -1,4 +1,4 @@
-# encoding: binary
+# encoding: utf-8
 
 require File.expand_path('../../../spec_helper', __FILE__)
 require 'bigdecimal'
@@ -46,28 +46,28 @@ module AMQ
                             "\x00\x00\x00\x00"
                           end
 
-          Table.encode(nil).should eql(encoded_value)
+          expect(Table.encode(nil)).to eql(encoded_value)
         end
 
         it "should serialize { :test => true }" do
-          Table.encode(:test => true).should eql("\x00\x00\x00\a\x04testt\x01")
+          expect(Table.encode(:test => true)).to eql("\x00\x00\x00\a\x04testt\x01")
         end
 
         it "should serialize { :test => false }" do
-          Table.encode(:test => false).should eql("\x00\x00\x00\a\x04testt\x00")
+          expect(Table.encode(:test => false)).to eql("\x00\x00\x00\a\x04testt\x00")
         end
 
         it "should serialize { :coordinates => { :latitude  => 59.35 } }" do
-          Table.encode(:coordinates => { :latitude  => 59.35 }).should eql("\x00\x00\x00#\vcoordinatesF\x00\x00\x00\x12\blatituded@M\xAC\xCC\xCC\xCC\xCC\xCD")
+          expect(Table.encode(:coordinates => { :latitude  => 59.35 })).to eql("\x00\x00\x00#\vcoordinatesF\x00\x00\x00\x12\blatituded@M\xAC\xCC\xCC\xCC\xCC\xCD")
         end
 
         it "should serialize { :coordinates => { :longitude => 18.066667 } }" do
-          Table.encode(:coordinates => { :longitude => 18.066667 }).should eql("\x00\x00\x00$\vcoordinatesF\x00\x00\x00\x13\tlongituded@2\x11\x11\x16\xA8\xB8\xF1")
+          expect(Table.encode(:coordinates => { :longitude => 18.066667 })).to eql("\x00\x00\x00$\vcoordinatesF\x00\x00\x00\x13\tlongituded@2\x11\x11\x16\xA8\xB8\xF1")
         end
 
         DATA.each do |data, encoded|
           it "should return #{encoded.inspect} for #{data.inspect}" do
-            Table.encode(data).should eql(encoded)
+            expect(Table.encode(data)).to eql(encoded)
           end
         end
       end
@@ -75,114 +75,114 @@ module AMQ
       describe ".decode" do
         DATA.each do |data, encoded|
           it "should return #{data.inspect} for #{encoded.inspect}" do
-            Table.decode(encoded).should eql(data)
+            expect(Table.decode(encoded)).to eql(data)
           end
 
           it "is capable of decoding what it encodes" do
-            Table.decode(Table.encode(data)).should == data
+            expect(Table.decode(Table.encode(data))).to eq(data)
           end
         end # DATA.each
 
 
         it "is capable of decoding boolean table values" do
           input1   = { "boolval" => true }
-          Table.decode(Table.encode(input1)).should == input1
+          expect(Table.decode(Table.encode(input1))).to eq(input1)
 
 
           input2   = { "boolval" => false }
-          Table.decode(Table.encode(input2)).should == input2
+          expect(Table.decode(Table.encode(input2))).to eq(input2)
         end
 
 
         it "is capable of decoding nil table values" do
           input   = { "nilval" => nil }
-          Table.decode(Table.encode(input)).should == input
+          expect(Table.decode(Table.encode(input))).to eq(input)
         end
 
         it "is capable of decoding nil table in nested hash/map values" do
           input   = { "hash" => {"nil" => nil} }
-          Table.decode(Table.encode(input)).should == input
+          expect(Table.decode(Table.encode(input))).to eq(input)
         end
 
         it "is capable of decoding string table values" do
           input   = { "stringvalue" => "string" }
-          Table.decode(Table.encode(input)).should == input
+          expect(Table.decode(Table.encode(input))).to eq(input)
         end
 
         it "is capable of decoding string table values with UTF-8 characters" do
           input   = { "строка" => "значение" }
-          Table.decode(Table.encode(input)).should == input
+          expect(Table.decode(Table.encode(input))).to eq(input)
         end
 
 
         it "is capable of decoding integer table values" do
           input   = { "intvalue" => 10 }
-          Table.decode(Table.encode(input)).should == input
+          expect(Table.decode(Table.encode(input))).to eq(input)
         end
 
 
 
         it "is capable of decoding long table values" do
           input   = { "longvalue" => 912598613 }
-          Table.decode(Table.encode(input)).should == input
+          expect(Table.decode(Table.encode(input))).to eq(input)
         end
 
 
 
         it "is capable of decoding float table values" do
           input   = { "floatvalue" => 100.0 }
-          Table.decode(Table.encode(input)).should == input
+          expect(Table.decode(Table.encode(input))).to eq(input)
         end
 
 
 
         it "is capable of decoding time table values" do
           input   = { "intvalue" => Time.parse("2011-07-14 01:17:46 +0400") }
-          Table.decode(Table.encode(input)).should == input
+          expect(Table.decode(Table.encode(input))).to eq(input)
         end
 
 
 
         it "is capable of decoding empty hash table values" do
           input   = { "hashvalue" => Hash.new }
-          Table.decode(Table.encode(input)).should == input
+          expect(Table.decode(Table.encode(input))).to eq(input)
         end
 
 
 
         it "is capable of decoding empty array table values" do
           input   = { "arrayvalue" => Array.new }
-          Table.decode(Table.encode(input)).should == input
+          expect(Table.decode(Table.encode(input))).to eq(input)
         end
 
 
         it "is capable of decoding single string value array table values" do
           input   = { "arrayvalue" => ["amq-protocol"] }
-          Table.decode(Table.encode(input)).should == input
+          expect(Table.decode(Table.encode(input))).to eq(input)
         end
 
 
 
         it "is capable of decoding simple nested hash table values" do
           input   = { "hashvalue" => { "a" => "b" } }
-          Table.decode(Table.encode(input)).should == input
+          expect(Table.decode(Table.encode(input))).to eq(input)
         end
 
 
 
         it "is capable of decoding nil table values" do
           input   = { "nil" => nil }
-          Table.decode(Table.encode(input)).should == input
+          expect(Table.decode(Table.encode(input))).to eq(input)
         end
 
         it 'is capable of decoding 8bit signed integers' do
           output = TableValueDecoder.decode_byte("\xC0",0).first
-          output.should == 192
+          expect(output).to eq(192)
         end
 
         it 'is capable of decoding 16bit signed integers' do
           output = TableValueDecoder.decode_short("\x06\x8D", 0).first
-          output.should == 1677
+          expect(output).to eq(1677)
         end
 
         it "is capable of decoding tables" do
@@ -195,7 +195,7 @@ module AMQ
             "longval"      => 912598613,
             "hashval"      => { "protocol" => "AMQP091", "true" => true, "false" => false, "nil" => nil }
           }
-          Table.decode(Table.encode(input)).should == input
+          expect(Table.decode(Table.encode(input))).to eq(input)
         end
 
 
@@ -218,7 +218,7 @@ module AMQ
               "nil"      => nil
             }
           }
-          Table.decode(Table.encode(input)).should == input
+          expect(Table.decode(Table.encode(input))).to eq(input)
         end
 
 
@@ -228,7 +228,7 @@ module AMQ
             "arrayval1" => [198, 3, 77, 8.0, ["inner", "array", { "oh" => "well", "it" => "should work", "3" => 6 }], "two", { "a" => "value", "is" => nil }],
             "arrayval2" => [198, 3, 77, "two", { "a" => "value", "is" => nil }, 8.0, ["inner", "array", { "oh" => "well", "it" => "should work", "3" => 6 }]]
           }
-          Table.decode(Table.encode(input1)).should == input1
+          expect(Table.decode(Table.encode(input1))).to eq(input1)
 
           now = Time.now
           input2 = {
@@ -244,10 +244,10 @@ module AMQ
                        "ary_field"    => ["one", 2.0, 3]
                      }
 
-          Table.decode(Table.encode(input2)).should == input2
+          expect(Table.decode(Table.encode(input2))).to eq(input2)
 
           input3 = { "timely" => { "now" => now } }
-          Table.decode(Table.encode(input3))["timely"]["now"].to_i.should == now.to_i
+          expect(Table.decode(Table.encode(input3))["timely"]["now"].to_i).to eq(now.to_i)
         end
 
       end # describe

--- a/spec/amq/protocol/table_spec.rb
+++ b/spec/amq/protocol/table_spec.rb
@@ -11,7 +11,6 @@ module AMQ
       timestamp    = Time.utc(2010, 12, 31, 23, 58, 59)
       bigdecimal_1 = BigDecimal.new("1.0")
       bigdecimal_2 = BigDecimal.new("5E-3")
-      bigdecimal_3 = BigDecimal.new("-0.01")
 
 
       DATA = if one_point_eight?

--- a/spec/amq/protocol/tx_spec.rb
+++ b/spec/amq/protocol/tx_spec.rb
@@ -11,8 +11,8 @@ module AMQ
           it 'encodes the parameters into a MethodFrame' do
             channel = 1
             method_frame = Select.encode(channel)
-            method_frame.payload.should == "\000Z\000\n"
-            method_frame.channel.should == 1
+            expect(method_frame.payload).to eq("\000Z\000\n")
+            expect(method_frame.channel).to eq(1)
           end
         end
       end
@@ -27,8 +27,8 @@ module AMQ
           it 'encodes the parameters into a MethodFrame' do
             channel = 1
             method_frame = Commit.encode(channel)
-            method_frame.payload.should == "\000Z\000\024"
-            method_frame.channel.should == 1
+            expect(method_frame.payload).to eq("\000Z\000\024")
+            expect(method_frame.channel).to eq(1)
           end
         end
       end
@@ -43,8 +43,8 @@ module AMQ
           it 'encodes the parameters into a MethodFrame' do
             channel = 1
             method_frame = Rollback.encode(channel)
-            method_frame.payload.should == "\000Z\000\036"
-            method_frame.channel.should == 1
+            expect(method_frame.payload).to eq("\000Z\000\036")
+            expect(method_frame.channel).to eq(1)
           end
         end
       end

--- a/spec/amq/protocol/value_decoder_spec.rb
+++ b/spec/amq/protocol/value_decoder_spec.rb
@@ -12,27 +12,27 @@ module AMQ
         input1 = [1, 2, 3]
 
         value, offset = described_class.decode_array(TableValueEncoder.encode(input1), 1)
-        value.size.should == 3
-        value.first.should == 1
-        value.should == input1
+        expect(value.size).to eq(3)
+        expect(value.first).to eq(1)
+        expect(value).to eq(input1)
 
 
 
         input2 = ["one", 2, "three"]
 
         value, offset = described_class.decode_array(TableValueEncoder.encode(input2), 1)
-        value.size.should == 3
-        value.first.should == "one"
-        value.should == input2
+        expect(value.size).to eq(3)
+        expect(value.first).to eq("one")
+        expect(value).to eq(input2)
 
 
 
         input3 = ["one", 2, "three", 4.0, 5000000.0]
 
         value, offset = described_class.decode_array(TableValueEncoder.encode(input3), 1)
-        value.size.should == 5
-        value.last.should == 5000000.0
-        value.should == input3
+        expect(value.size).to eq(5)
+        expect(value.last).to eq(5000000.0)
+        expect(value).to eq(input3)
       end
 
 
@@ -46,18 +46,18 @@ module AMQ
 
 
         value, offset = described_class.decode_array(data1, 1)
-        value.size.should == 2
-        value.first.should == Hash["one" => 2]
-        value.should == input1
+        expect(value.size).to eq(2)
+        expect(value.first).to eq(Hash["one" => 2])
+        expect(value).to eq(input1)
 
 
 
         input2 = ["one", 2, { "three" => { "four" => 5.0 } }]
 
         value, offset = described_class.decode_array(TableValueEncoder.encode(input2), 1)
-        value.size.should == 3
-        value.last["three"]["four"].should == 5.0
-        value.should == input2
+        expect(value.size).to eq(3)
+        expect(value.last["three"]["four"]).to eq(5.0)
+        expect(value).to eq(input2)
       end
 
       it "is capable of decoding 32 bit float values" do
@@ -65,7 +65,7 @@ module AMQ
         data  = TableValueEncoder.encode(input)
 
         value, offset = described_class.decode_32bit_float(data, 1)
-        value.should == 10.0
+        expect(value).to eq(10.0)
       end
 
       context "8bit/byte decoding" do
@@ -80,7 +80,7 @@ module AMQ
 
         it "is capable of decoding byte values" do
           examples.each do |key, value|
-            described_class.decode_byte(value, 0).first.should == key
+            expect(described_class.decode_byte(value, 0).first).to eq(key)
           end
         end
       end

--- a/spec/amq/protocol/value_decoder_spec.rb
+++ b/spec/amq/protocol/value_decoder_spec.rb
@@ -64,7 +64,7 @@ module AMQ
         input = Float32Bit.new(10.0)
         data  = TableValueEncoder.encode(input)
 
-        value, offset = described_class.decode_32bit_float(data, 1)
+        value = described_class.decode_32bit_float(data, 1)[0]
         expect(value).to eq(10.0)
       end
 

--- a/spec/amq/protocol/value_encoder_spec.rb
+++ b/spec/amq/protocol/value_encoder_spec.rb
@@ -11,69 +11,69 @@ module AMQ
 
 
       it "calculates size of string field values" do
-        described_class.field_value_size("amqp").should == 9
-        described_class.encode("amqp").bytesize.should == 9
+        expect(described_class.field_value_size("amqp")).to eq(9)
+        expect(described_class.encode("amqp").bytesize).to eq(9)
 
-        described_class.field_value_size("amq-protocol").should == 17
-        described_class.encode("amq-protocol").bytesize.should == 17
+        expect(described_class.field_value_size("amq-protocol")).to eq(17)
+        expect(described_class.encode("amq-protocol").bytesize).to eq(17)
 
-        described_class.field_value_size("à bientôt").should == 16
-        described_class.encode("à bientôt").bytesize.should == 16
+        expect(described_class.field_value_size("à bientôt")).to eq(16)
+        expect(described_class.encode("à bientôt").bytesize).to eq(16)
       end
 
       it "calculates size of integer field values" do
-        described_class.field_value_size(10).should == 5
-        described_class.encode(10).bytesize.should == 5
+        expect(described_class.field_value_size(10)).to eq(5)
+        expect(described_class.encode(10).bytesize).to eq(5)
       end
 
       it "calculates size of float field values (considering them to be 64-bit)" do
-        described_class.field_value_size(10.0).should == 9
-        described_class.encode(10.0).bytesize.should == 9
+        expect(described_class.field_value_size(10.0)).to eq(9)
+        expect(described_class.encode(10.0).bytesize).to eq(9)
 
-        described_class.field_value_size(120000.0).should == 9
-        described_class.encode(120000.0).bytesize.should == 9
+        expect(described_class.field_value_size(120000.0)).to eq(9)
+        expect(described_class.encode(120000.0).bytesize).to eq(9)
       end
 
       it "calculates size of float field values (boxed as 32-bit)" do
-        described_class.encode(AMQ::Protocol::Float32Bit.new(10.0)).bytesize.should == 5
-        described_class.encode(AMQ::Protocol::Float32Bit.new(120000.0)).bytesize.should == 5
+        expect(described_class.encode(AMQ::Protocol::Float32Bit.new(10.0)).bytesize).to eq(5)
+        expect(described_class.encode(AMQ::Protocol::Float32Bit.new(120000.0)).bytesize).to eq(5)
       end
 
       it "calculates size of boolean field values" do
-        described_class.field_value_size(true).should == 2
-        described_class.encode(true).bytesize.should == 2
+        expect(described_class.field_value_size(true)).to eq(2)
+        expect(described_class.encode(true).bytesize).to eq(2)
 
-        described_class.field_value_size(false).should == 2
-        described_class.encode(false).bytesize.should == 2
+        expect(described_class.field_value_size(false)).to eq(2)
+        expect(described_class.encode(false).bytesize).to eq(2)
       end
 
       it "calculates size of void field values" do
-        described_class.field_value_size(nil).should == 1
-        described_class.encode(nil).bytesize.should == 1
+        expect(described_class.field_value_size(nil)).to eq(1)
+        expect(described_class.encode(nil).bytesize).to eq(1)
       end
 
       it "calculates size of time field values" do
         t = Time.parse("2011-07-14 01:17:46 +0400")
 
-        described_class.field_value_size(t).should == 9
-        described_class.encode(t).bytesize.should == 9
+        expect(described_class.field_value_size(t)).to eq(9)
+        expect(described_class.encode(t).bytesize).to eq(9)
       end
 
 
       it "calculates size of basic table field values" do
         input1   = { "key" => "value" }
-        described_class.field_value_size(input1).should == 19
-        described_class.encode(input1).bytesize.should == 19
+        expect(described_class.field_value_size(input1)).to eq(19)
+        expect(described_class.encode(input1).bytesize).to eq(19)
 
 
         input2   = { "intval" => 1 }
-        described_class.field_value_size(input2).should == 17
-        described_class.encode(input2).bytesize.should == 17
+        expect(described_class.field_value_size(input2)).to eq(17)
+        expect(described_class.encode(input2).bytesize).to eq(17)
 
 
         input3   = { "intval" => 1, "key" => "value" }
-        described_class.field_value_size(input3).should == 31
-        described_class.encode(input3).bytesize.should == 31
+        expect(described_class.field_value_size(input3)).to eq(31)
+        expect(described_class.encode(input3).bytesize).to eq(31)
       end
 
 
@@ -96,9 +96,9 @@ module AMQ
           }
         }
 
-        described_class.field_value_size(input1).should == 162
+        expect(described_class.field_value_size(input1)).to eq(162)
         # puts(described_class.encode(input1).inspect)
-        described_class.encode(input1).bytesize.should == 162
+        expect(described_class.encode(input1).bytesize).to eq(162)
 
 
 
@@ -112,30 +112,30 @@ module AMQ
           "hashval"      => { "protocol" => "AMQP091", "true" => true, "false" => false, "nil" => nil }
         }
 
-        described_class.field_value_size(input2).should == 150
-        described_class.encode(input2).bytesize.should == 150
+        expect(described_class.field_value_size(input2)).to eq(150)
+        expect(described_class.encode(input2).bytesize).to eq(150)
       end
 
       it "calculates size of basic array field values" do
         input1 = [1, 2, 3]
 
-        described_class.field_value_size(input1).should == 20
-        described_class.encode(input1).bytesize.should == 20
+        expect(described_class.field_value_size(input1)).to eq(20)
+        expect(described_class.encode(input1).bytesize).to eq(20)
 
 
         input2 = ["one", "two", "three"]
-        described_class.field_value_size(input2).should == 31
-        described_class.encode(input2).bytesize.should == 31
+        expect(described_class.field_value_size(input2)).to eq(31)
+        expect(described_class.encode(input2).bytesize).to eq(31)
 
 
         input3 = ["one", 2, "three"]
-        described_class.field_value_size(input3).should == 28
-        described_class.encode(input3).bytesize.should == 28
+        expect(described_class.field_value_size(input3)).to eq(28)
+        expect(described_class.encode(input3).bytesize).to eq(28)
 
 
         input4 = ["one", 2, "three", ["four", 5, [6.0]]]
-        described_class.field_value_size(input4).should == 61
-        described_class.encode(input4).bytesize.should == 61
+        expect(described_class.field_value_size(input4)).to eq(61)
+        expect(described_class.encode(input4).bytesize).to eq(61)
       end
 
 

--- a/spec/amq/protocol_spec.rb
+++ b/spec/amq/protocol_spec.rb
@@ -6,810 +6,810 @@ require File.expand_path('../../spec_helper', __FILE__)
 module AMQ
   describe Protocol do
     it "should have PROTOCOL_VERSION constant" do
-      Protocol::PROTOCOL_VERSION.should match(/^\d+\.\d+\.\d$/)
+      expect(Protocol::PROTOCOL_VERSION).to match(/^\d+\.\d+\.\d$/)
     end
 
     it "should have DEFAULT_PORT constant" do
-      Protocol::DEFAULT_PORT.should be_kind_of(Integer)
+      expect(Protocol::DEFAULT_PORT).to be_kind_of(Integer)
     end
 
     it "should have PREAMBLE constant" do
-      Protocol::PREAMBLE.should be_kind_of(String)
+      expect(Protocol::PREAMBLE).to be_kind_of(String)
     end
 
     describe Protocol::Error do
       it "should be an exception class" do
-        Protocol::Error.should < Exception
+        expect(Protocol::Error.ancestors).to include(Exception)
       end
     end
 
     describe Protocol::Connection do
       it "should be a subclass of Class" do
-        Protocol::Connection.superclass.should == Protocol::Class
+        expect(Protocol::Connection.superclass).to eq(Protocol::Class)
       end
 
       it "should have name equal to connection" do
-        Protocol::Connection.name.should eql("connection")
+        expect(Protocol::Connection.name).to eql("connection")
       end
 
       it "should have method id equal to 10" do
-        Protocol::Connection.method_id.should == 10
+        expect(Protocol::Connection.method_id).to eq(10)
       end
 
       describe Protocol::Connection::Start do
         it "should be a subclass of Method" do
-          Protocol::Connection::Start.superclass.should == Protocol::Method
+          expect(Protocol::Connection::Start.superclass).to eq(Protocol::Method)
         end
 
         it "should have method name equal to connection.start" do
-          Protocol::Connection::Start.name.should eql("connection.start")
+          expect(Protocol::Connection::Start.name).to eql("connection.start")
         end
 
         it "should have method id equal to 10" do
-          Protocol::Connection::Start.method_id.should == 10
+          expect(Protocol::Connection::Start.method_id).to eq(10)
         end
       end
 
       describe Protocol::Connection::StartOk do
         it "should be a subclass of Method" do
-          Protocol::Connection::StartOk.superclass.should == Protocol::Method
+          expect(Protocol::Connection::StartOk.superclass).to eq(Protocol::Method)
         end
 
         it "should have method name equal to connection.start-ok" do
-          Protocol::Connection::StartOk.name.should eql("connection.start-ok")
+          expect(Protocol::Connection::StartOk.name).to eql("connection.start-ok")
         end
 
         it "has method id equal to 11" do
-          Protocol::Connection::StartOk.method_id.should == 11
+          expect(Protocol::Connection::StartOk.method_id).to eq(11)
         end
       end
 
       describe Protocol::Connection::Secure do
         it "should be a subclass of Method" do
-          Protocol::Connection::Secure.superclass.should == Protocol::Method
+          expect(Protocol::Connection::Secure.superclass).to eq(Protocol::Method)
         end
 
         it "should have method name equal to connection.secure" do
-          Protocol::Connection::Secure.name.should eql("connection.secure")
+          expect(Protocol::Connection::Secure.name).to eql("connection.secure")
         end
 
         it "has method id equal to 20" do
-          Protocol::Connection::Secure.method_id.should == 20
+          expect(Protocol::Connection::Secure.method_id).to eq(20)
         end
       end
 
       describe Protocol::Connection::SecureOk do
         it "should be a subclass of Method" do
-          Protocol::Connection::SecureOk.superclass.should == Protocol::Method
+          expect(Protocol::Connection::SecureOk.superclass).to eq(Protocol::Method)
         end
 
         it "should have method name equal to connection.secure-ok" do
-          Protocol::Connection::SecureOk.name.should eql("connection.secure-ok")
+          expect(Protocol::Connection::SecureOk.name).to eql("connection.secure-ok")
         end
 
         it "has method id equal to 21" do
-          Protocol::Connection::SecureOk.method_id.should == 21
+          expect(Protocol::Connection::SecureOk.method_id).to eq(21)
         end
       end
 
       describe Protocol::Connection::Tune do
         it "should be a subclass of Method" do
-          Protocol::Connection::Tune.superclass.should == Protocol::Method
+          expect(Protocol::Connection::Tune.superclass).to eq(Protocol::Method)
         end
 
         it "should have method name equal to connection.tune" do
-          Protocol::Connection::Tune.name.should eql("connection.tune")
+          expect(Protocol::Connection::Tune.name).to eql("connection.tune")
         end
 
         it "has method id equal to 30" do
-          Protocol::Connection::Tune.method_id.should == 30
+          expect(Protocol::Connection::Tune.method_id).to eq(30)
         end
       end
 
       describe Protocol::Connection::TuneOk do
         it "should be a subclass of Method" do
-          Protocol::Connection::TuneOk.superclass.should == Protocol::Method
+          expect(Protocol::Connection::TuneOk.superclass).to eq(Protocol::Method)
         end
 
         it "should have method name equal to connection.tune-ok" do
-          Protocol::Connection::TuneOk.name.should eql("connection.tune-ok")
+          expect(Protocol::Connection::TuneOk.name).to eql("connection.tune-ok")
         end
 
         it "has method id equal to 31" do
-          Protocol::Connection::TuneOk.method_id.should == 31
+          expect(Protocol::Connection::TuneOk.method_id).to eq(31)
         end
 
         describe ".encode" do
           it do
             frame = Protocol::Connection::TuneOk.encode(0, 131072, 0)
-            frame.payload.should eql("\x00\n\x00\x1F\x00\x00\x00\x02\x00\x00\x00\x00")
+            expect(frame.payload).to eql("\x00\n\x00\x1F\x00\x00\x00\x02\x00\x00\x00\x00")
           end
         end
       end
 
       describe Protocol::Connection::Open do
         it "should be a subclass of Method" do
-          Protocol::Connection::Open.superclass.should == Protocol::Method
+          expect(Protocol::Connection::Open.superclass).to eq(Protocol::Method)
         end
 
         it "should have method name equal to connection.open" do
-          Protocol::Connection::Open.name.should eql("connection.open")
+          expect(Protocol::Connection::Open.name).to eql("connection.open")
         end
 
         it "has method id equal to 40" do
-          Protocol::Connection::Open.method_id.should == 40
+          expect(Protocol::Connection::Open.method_id).to eq(40)
         end
       end
 
       describe Protocol::Connection::OpenOk do
         it "should be a subclass of Method" do
-          Protocol::Connection::OpenOk.superclass.should == Protocol::Method
+          expect(Protocol::Connection::OpenOk.superclass).to eq(Protocol::Method)
         end
 
         it "should have method name equal to connection.open-ok" do
-          Protocol::Connection::OpenOk.name.should eql("connection.open-ok")
+          expect(Protocol::Connection::OpenOk.name).to eql("connection.open-ok")
         end
 
         it "has method id equal to 41" do
-          Protocol::Connection::OpenOk.method_id.should == 41
+          expect(Protocol::Connection::OpenOk.method_id).to eq(41)
         end
       end
 
       describe Protocol::Connection::Close do
         it "should be a subclass of Method" do
-          Protocol::Connection::Close.superclass.should == Protocol::Method
+          expect(Protocol::Connection::Close.superclass).to eq(Protocol::Method)
         end
 
         it "should have method name equal to connection.close" do
-          Protocol::Connection::Close.name.should eql("connection.close")
+          expect(Protocol::Connection::Close.name).to eql("connection.close")
         end
 
         it "has method id equal to 50" do
-          Protocol::Connection::Close.method_id.should == 50
+          expect(Protocol::Connection::Close.method_id).to eq(50)
         end
       end
 
       describe Protocol::Connection::CloseOk do
         it "should be a subclass of Method" do
-          Protocol::Connection::CloseOk.superclass.should == Protocol::Method
+          expect(Protocol::Connection::CloseOk.superclass).to eq(Protocol::Method)
         end
 
         it "should have method name equal to connection.close-ok" do
-          Protocol::Connection::CloseOk.name.should eql("connection.close-ok")
+          expect(Protocol::Connection::CloseOk.name).to eql("connection.close-ok")
         end
 
         it "has method id equal to 51" do
-          Protocol::Connection::CloseOk.method_id.should == 51
+          expect(Protocol::Connection::CloseOk.method_id).to eq(51)
         end
       end
     end
 
     describe Protocol::Channel do
       it "should be a subclass of Class" do
-        Protocol::Channel.superclass.should == Protocol::Class
+        expect(Protocol::Channel.superclass).to eq(Protocol::Class)
       end
 
       it "should have name equal to channel" do
-        Protocol::Channel.name.should eql("channel")
+        expect(Protocol::Channel.name).to eql("channel")
       end
 
       it "has method id equal to 20" do
-        Protocol::Channel.method_id.should == 20
+        expect(Protocol::Channel.method_id).to eq(20)
       end
 
       describe Protocol::Channel::Open do
         it "should be a subclass of Method" do
-          Protocol::Channel::Open.superclass.should == Protocol::Method
+          expect(Protocol::Channel::Open.superclass).to eq(Protocol::Method)
         end
 
         it "should have method name equal to channel.open" do
-          Protocol::Channel::Open.name.should eql("channel.open")
+          expect(Protocol::Channel::Open.name).to eql("channel.open")
         end
 
         it "has method id equal to 10" do
-          Protocol::Channel::Open.method_id.should == 10
+          expect(Protocol::Channel::Open.method_id).to eq(10)
         end
       end
 
       describe Protocol::Channel::OpenOk do
         it "should be a subclass of Method" do
-          Protocol::Channel::OpenOk.superclass.should == Protocol::Method
+          expect(Protocol::Channel::OpenOk.superclass).to eq(Protocol::Method)
         end
 
         it "should have method name equal to channel.open-ok" do
-          Protocol::Channel::OpenOk.name.should eql("channel.open-ok")
+          expect(Protocol::Channel::OpenOk.name).to eql("channel.open-ok")
         end
 
         it "has method id equal to 11" do
-          Protocol::Channel::OpenOk.method_id.should == 11
+          expect(Protocol::Channel::OpenOk.method_id).to eq(11)
         end
       end
 
       describe Protocol::Channel::Flow do
         it "should be a subclass of Method" do
-          Protocol::Channel::Flow.superclass.should == Protocol::Method
+          expect(Protocol::Channel::Flow.superclass).to eq(Protocol::Method)
         end
 
         it "should have method name equal to channel.flow" do
-          Protocol::Channel::Flow.name.should eql("channel.flow")
+          expect(Protocol::Channel::Flow.name).to eql("channel.flow")
         end
 
         it "has method id equal to 20" do
-          Protocol::Channel::Flow.method_id.should == 20
+          expect(Protocol::Channel::Flow.method_id).to eq(20)
         end
       end
 
       describe Protocol::Channel::FlowOk do
         it "should be a subclass of Method" do
-          Protocol::Channel::FlowOk.superclass.should == Protocol::Method
+          expect(Protocol::Channel::FlowOk.superclass).to eq(Protocol::Method)
         end
 
         it "should have method name equal to channel.flow-ok" do
-          Protocol::Channel::FlowOk.name.should eql("channel.flow-ok")
+          expect(Protocol::Channel::FlowOk.name).to eql("channel.flow-ok")
         end
 
         it "has method id equal to 21" do
-          Protocol::Channel::FlowOk.method_id.should == 21
+          expect(Protocol::Channel::FlowOk.method_id).to eq(21)
         end
       end
 
       describe Protocol::Channel::Close do
         it "should be a subclass of Method" do
-          Protocol::Channel::Close.superclass.should == Protocol::Method
+          expect(Protocol::Channel::Close.superclass).to eq(Protocol::Method)
         end
 
         it "should have method name equal to channel.close" do
-          Protocol::Channel::Close.name.should eql("channel.close")
+          expect(Protocol::Channel::Close.name).to eql("channel.close")
         end
 
         it "has method id equal to 40" do
-          Protocol::Channel::Close.method_id.should == 40
+          expect(Protocol::Channel::Close.method_id).to eq(40)
         end
       end
 
       describe Protocol::Channel::CloseOk do
         it "should be a subclass of Method" do
-          Protocol::Channel::CloseOk.superclass.should == Protocol::Method
+          expect(Protocol::Channel::CloseOk.superclass).to eq(Protocol::Method)
         end
 
         it "should have method name equal to channel.close-ok" do
-          Protocol::Channel::CloseOk.name.should eql("channel.close-ok")
+          expect(Protocol::Channel::CloseOk.name).to eql("channel.close-ok")
         end
 
         it "has method id equal to 41" do
-          Protocol::Channel::CloseOk.method_id.should == 41
+          expect(Protocol::Channel::CloseOk.method_id).to eq(41)
         end
       end
     end
 
     describe Protocol::Exchange do
       it "should be a subclass of Class" do
-        Protocol::Exchange.superclass.should == Protocol::Class
+        expect(Protocol::Exchange.superclass).to eq(Protocol::Class)
       end
 
       it "should have name equal to exchange" do
-        Protocol::Exchange.name.should eql("exchange")
+        expect(Protocol::Exchange.name).to eql("exchange")
       end
 
       it "has method id equal to 40" do
-        Protocol::Exchange.method_id.should == 40
+        expect(Protocol::Exchange.method_id).to eq(40)
       end
 
       describe Protocol::Exchange::Declare do
         it "should be a subclass of Method" do
-          Protocol::Exchange::Declare.superclass.should == Protocol::Method
+          expect(Protocol::Exchange::Declare.superclass).to eq(Protocol::Method)
         end
 
         it "should have method name equal to exchange.declare" do
-          Protocol::Exchange::Declare.name.should eql("exchange.declare")
+          expect(Protocol::Exchange::Declare.name).to eql("exchange.declare")
         end
 
         it "has method id equal to 10" do
-          Protocol::Exchange::Declare.method_id.should == 10
+          expect(Protocol::Exchange::Declare.method_id).to eq(10)
         end
       end
 
       describe Protocol::Exchange::DeclareOk do
         it "should be a subclass of Method" do
-          Protocol::Exchange::DeclareOk.superclass.should == Protocol::Method
+          expect(Protocol::Exchange::DeclareOk.superclass).to eq(Protocol::Method)
         end
 
         it "should have method name equal to exchange.declare-ok" do
-          Protocol::Exchange::DeclareOk.name.should eql("exchange.declare-ok")
+          expect(Protocol::Exchange::DeclareOk.name).to eql("exchange.declare-ok")
         end
 
         it "has method id equal to 11" do
-          Protocol::Exchange::DeclareOk.method_id.should == 11
+          expect(Protocol::Exchange::DeclareOk.method_id).to eq(11)
         end
       end
 
       describe Protocol::Exchange::Delete do
         it "should be a subclass of Method" do
-          Protocol::Exchange::Delete.superclass.should == Protocol::Method
+          expect(Protocol::Exchange::Delete.superclass).to eq(Protocol::Method)
         end
 
         it "should have method name equal to exchange.delete" do
-          Protocol::Exchange::Delete.name.should eql("exchange.delete")
+          expect(Protocol::Exchange::Delete.name).to eql("exchange.delete")
         end
 
         it "has method id equal to 20" do
-          Protocol::Exchange::Delete.method_id.should == 20
+          expect(Protocol::Exchange::Delete.method_id).to eq(20)
         end
       end
 
       describe Protocol::Exchange::DeleteOk do
         it "should be a subclass of Method" do
-          Protocol::Exchange::DeleteOk.superclass.should == Protocol::Method
+          expect(Protocol::Exchange::DeleteOk.superclass).to eq(Protocol::Method)
         end
 
         it "should have method name equal to exchange.delete-ok" do
-          Protocol::Exchange::DeleteOk.name.should eql("exchange.delete-ok")
+          expect(Protocol::Exchange::DeleteOk.name).to eql("exchange.delete-ok")
         end
 
         it "has method id equal to 21" do
-          Protocol::Exchange::DeleteOk.method_id.should == 21
+          expect(Protocol::Exchange::DeleteOk.method_id).to eq(21)
         end
       end
 
       describe Protocol::Exchange::Bind do
         it "should be a subclass of Method" do
-          Protocol::Exchange::Bind.superclass.should == Protocol::Method
+          expect(Protocol::Exchange::Bind.superclass).to eq(Protocol::Method)
         end
 
         it "should have method name equal to exchange.bind" do
-          Protocol::Exchange::Bind.name.should eql("exchange.bind")
+          expect(Protocol::Exchange::Bind.name).to eql("exchange.bind")
         end
 
         it "has method id equal to 30" do
-          Protocol::Exchange::Bind.method_id.should == 30
+          expect(Protocol::Exchange::Bind.method_id).to eq(30)
         end
       end
 
       describe Protocol::Exchange::BindOk do
         it "should be a subclass of Method" do
-          Protocol::Exchange::BindOk.superclass.should == Protocol::Method
+          expect(Protocol::Exchange::BindOk.superclass).to eq(Protocol::Method)
         end
 
         it "should have method name equal to exchange.bind-ok" do
-          Protocol::Exchange::BindOk.name.should eql("exchange.bind-ok")
+          expect(Protocol::Exchange::BindOk.name).to eql("exchange.bind-ok")
         end
 
         it "has method id equal to 31" do
-          Protocol::Exchange::BindOk.method_id.should == 31
+          expect(Protocol::Exchange::BindOk.method_id).to eq(31)
         end
       end
 
       describe Protocol::Exchange::Unbind do
         it "should be a subclass of Method" do
-          Protocol::Exchange::Unbind.superclass.should == Protocol::Method
+          expect(Protocol::Exchange::Unbind.superclass).to eq(Protocol::Method)
         end
 
         it "should have method name equal to exchange.unbind" do
-          Protocol::Exchange::Unbind.name.should eql("exchange.unbind")
+          expect(Protocol::Exchange::Unbind.name).to eql("exchange.unbind")
         end
 
         it "has method id equal to 40" do
-          Protocol::Exchange::Unbind.method_id.should == 40
+          expect(Protocol::Exchange::Unbind.method_id).to eq(40)
         end
       end
 
       describe Protocol::Exchange::UnbindOk do
         it "should be a subclass of Method" do
-          Protocol::Exchange::UnbindOk.superclass.should == Protocol::Method
+          expect(Protocol::Exchange::UnbindOk.superclass).to eq(Protocol::Method)
         end
 
         it "should have method name equal to exchange.unbind-ok" do
-          Protocol::Exchange::UnbindOk.name.should eql("exchange.unbind-ok")
+          expect(Protocol::Exchange::UnbindOk.name).to eql("exchange.unbind-ok")
         end
 
         it "has method id equal to 51" do
-          Protocol::Exchange::UnbindOk.method_id.should == 51
+          expect(Protocol::Exchange::UnbindOk.method_id).to eq(51)
         end
       end
     end
 
     describe Protocol::Queue do
       it "should be a subclass of Class" do
-        Protocol::Queue.superclass.should == Protocol::Class
+        expect(Protocol::Queue.superclass).to eq(Protocol::Class)
       end
 
       it "should have name equal to queue" do
-        Protocol::Queue.name.should eql("queue")
+        expect(Protocol::Queue.name).to eql("queue")
       end
 
       it "has method id equal to 50" do
-        Protocol::Queue.method_id.should == 50
+        expect(Protocol::Queue.method_id).to eq(50)
       end
 
       describe Protocol::Queue::Declare do
         it "should be a subclass of Method" do
-          Protocol::Queue::Declare.superclass.should == Protocol::Method
+          expect(Protocol::Queue::Declare.superclass).to eq(Protocol::Method)
         end
 
         it "should have method name equal to queue.declare" do
-          Protocol::Queue::Declare.name.should eql("queue.declare")
+          expect(Protocol::Queue::Declare.name).to eql("queue.declare")
         end
 
         it "has method id equal to 10" do
-          Protocol::Queue::Declare.method_id.should == 10
+          expect(Protocol::Queue::Declare.method_id).to eq(10)
         end
       end
 
       describe Protocol::Queue::DeclareOk do
         it "should be a subclass of Method" do
-          Protocol::Queue::DeclareOk.superclass.should == Protocol::Method
+          expect(Protocol::Queue::DeclareOk.superclass).to eq(Protocol::Method)
         end
 
         it "should have method name equal to queue.declare-ok" do
-          Protocol::Queue::DeclareOk.name.should eql("queue.declare-ok")
+          expect(Protocol::Queue::DeclareOk.name).to eql("queue.declare-ok")
         end
 
         it "has method id equal to 11" do
-          Protocol::Queue::DeclareOk.method_id.should == 11
+          expect(Protocol::Queue::DeclareOk.method_id).to eq(11)
         end
       end
 
       describe Protocol::Queue::Bind do
         it "should be a subclass of Method" do
-          Protocol::Queue::Bind.superclass.should == Protocol::Method
+          expect(Protocol::Queue::Bind.superclass).to eq(Protocol::Method)
         end
 
         it "should have method name equal to queue.bind" do
-          Protocol::Queue::Bind.name.should eql("queue.bind")
+          expect(Protocol::Queue::Bind.name).to eql("queue.bind")
         end
 
         it "has method id equal to 20" do
-          Protocol::Queue::Bind.method_id.should == 20
+          expect(Protocol::Queue::Bind.method_id).to eq(20)
         end
       end
 
       describe Protocol::Queue::BindOk do
         it "should be a subclass of Method" do
-          Protocol::Queue::BindOk.superclass.should == Protocol::Method
+          expect(Protocol::Queue::BindOk.superclass).to eq(Protocol::Method)
         end
 
         it "should have method name equal to queue.bind-ok" do
-          Protocol::Queue::BindOk.name.should eql("queue.bind-ok")
+          expect(Protocol::Queue::BindOk.name).to eql("queue.bind-ok")
         end
 
         it "has method id equal to 21" do
-          Protocol::Queue::BindOk.method_id.should == 21
+          expect(Protocol::Queue::BindOk.method_id).to eq(21)
         end
       end
 
       describe Protocol::Queue::Purge do
         it "should be a subclass of Method" do
-          Protocol::Queue::Purge.superclass.should == Protocol::Method
+          expect(Protocol::Queue::Purge.superclass).to eq(Protocol::Method)
         end
 
         it "should have method name equal to queue.purge" do
-          Protocol::Queue::Purge.name.should eql("queue.purge")
+          expect(Protocol::Queue::Purge.name).to eql("queue.purge")
         end
 
         it "has method id equal to 30" do
-          Protocol::Queue::Purge.method_id.should == 30
+          expect(Protocol::Queue::Purge.method_id).to eq(30)
         end
       end
 
       describe Protocol::Queue::PurgeOk do
         it "should be a subclass of Method" do
-          Protocol::Queue::PurgeOk.superclass.should == Protocol::Method
+          expect(Protocol::Queue::PurgeOk.superclass).to eq(Protocol::Method)
         end
 
         it "should have method name equal to queue.purge-ok" do
-          Protocol::Queue::PurgeOk.name.should eql("queue.purge-ok")
+          expect(Protocol::Queue::PurgeOk.name).to eql("queue.purge-ok")
         end
 
         it "has method id equal to 31" do
-          Protocol::Queue::PurgeOk.method_id.should == 31
+          expect(Protocol::Queue::PurgeOk.method_id).to eq(31)
         end
       end
 
       describe Protocol::Queue::Delete do
         it "should be a subclass of Method" do
-          Protocol::Queue::Delete.superclass.should == Protocol::Method
+          expect(Protocol::Queue::Delete.superclass).to eq(Protocol::Method)
         end
 
         it "should have method name equal to queue.delete" do
-          Protocol::Queue::Delete.name.should eql("queue.delete")
+          expect(Protocol::Queue::Delete.name).to eql("queue.delete")
         end
 
         it "has method id equal to 40" do
-          Protocol::Queue::Delete.method_id.should == 40
+          expect(Protocol::Queue::Delete.method_id).to eq(40)
         end
       end
 
       describe Protocol::Queue::DeleteOk do
         it "should be a subclass of Method" do
-          Protocol::Queue::DeleteOk.superclass.should == Protocol::Method
+          expect(Protocol::Queue::DeleteOk.superclass).to eq(Protocol::Method)
         end
 
         it "should have method name equal to queue.delete-ok" do
-          Protocol::Queue::DeleteOk.name.should eql("queue.delete-ok")
+          expect(Protocol::Queue::DeleteOk.name).to eql("queue.delete-ok")
         end
 
         it "has method id equal to 41" do
-          Protocol::Queue::DeleteOk.method_id.should == 41
+          expect(Protocol::Queue::DeleteOk.method_id).to eq(41)
         end
       end
 
       describe Protocol::Queue::Unbind do
         it "should be a subclass of Method" do
-          Protocol::Queue::Unbind.superclass.should == Protocol::Method
+          expect(Protocol::Queue::Unbind.superclass).to eq(Protocol::Method)
         end
 
         it "should have method name equal to queue.unbind" do
-          Protocol::Queue::Unbind.name.should eql("queue.unbind")
+          expect(Protocol::Queue::Unbind.name).to eql("queue.unbind")
         end
 
         it "has method id equal to 50" do
-          Protocol::Queue::Unbind.method_id.should == 50
+          expect(Protocol::Queue::Unbind.method_id).to eq(50)
         end
       end
 
       describe Protocol::Queue::UnbindOk do
         it "should be a subclass of Method" do
-          Protocol::Queue::UnbindOk.superclass.should == Protocol::Method
+          expect(Protocol::Queue::UnbindOk.superclass).to eq(Protocol::Method)
         end
 
         it "should have method name equal to queue.unbind-ok" do
-          Protocol::Queue::UnbindOk.name.should eql("queue.unbind-ok")
+          expect(Protocol::Queue::UnbindOk.name).to eql("queue.unbind-ok")
         end
 
         it "has method id equal to 51" do
-          Protocol::Queue::UnbindOk.method_id.should == 51
+          expect(Protocol::Queue::UnbindOk.method_id).to eq(51)
         end
       end
     end
 
     describe Protocol::Basic do
       it "should be a subclass of Class" do
-        Protocol::Basic.superclass.should == Protocol::Class
+        expect(Protocol::Basic.superclass).to eq(Protocol::Class)
       end
 
       it "should have name equal to basic" do
-        Protocol::Basic.name.should eql("basic")
+        expect(Protocol::Basic.name).to eql("basic")
       end
 
       it "has method id equal to 60" do
-        Protocol::Basic.method_id.should == 60
+        expect(Protocol::Basic.method_id).to eq(60)
       end
 
       describe Protocol::Basic::Qos do
         it "should be a subclass of Method" do
-          Protocol::Basic::Qos.superclass.should == Protocol::Method
+          expect(Protocol::Basic::Qos.superclass).to eq(Protocol::Method)
         end
 
         it "should have method name equal to basic.qos" do
-          Protocol::Basic::Qos.name.should eql("basic.qos")
+          expect(Protocol::Basic::Qos.name).to eql("basic.qos")
         end
 
         it "has method id equal to 10" do
-          Protocol::Basic::Qos.method_id.should == 10
+          expect(Protocol::Basic::Qos.method_id).to eq(10)
         end
       end
 
       describe Protocol::Basic::QosOk do
         it "should be a subclass of Method" do
-          Protocol::Basic::QosOk.superclass.should == Protocol::Method
+          expect(Protocol::Basic::QosOk.superclass).to eq(Protocol::Method)
         end
 
         it "should have method name equal to basic.qos-ok" do
-          Protocol::Basic::QosOk.name.should eql("basic.qos-ok")
+          expect(Protocol::Basic::QosOk.name).to eql("basic.qos-ok")
         end
 
         it "has method id equal to 11" do
-          Protocol::Basic::QosOk.method_id.should == 11
+          expect(Protocol::Basic::QosOk.method_id).to eq(11)
         end
       end
 
       describe Protocol::Basic::Consume do
         it "should be a subclass of Method" do
-          Protocol::Basic::Consume.superclass.should == Protocol::Method
+          expect(Protocol::Basic::Consume.superclass).to eq(Protocol::Method)
         end
 
         it "should have method name equal to basic.consume" do
-          Protocol::Basic::Consume.name.should eql("basic.consume")
+          expect(Protocol::Basic::Consume.name).to eql("basic.consume")
         end
 
         it "has method id equal to 20" do
-          Protocol::Basic::Consume.method_id.should == 20
+          expect(Protocol::Basic::Consume.method_id).to eq(20)
         end
       end
 
       describe Protocol::Basic::ConsumeOk do
         it "should be a subclass of Method" do
-          Protocol::Basic::ConsumeOk.superclass.should == Protocol::Method
+          expect(Protocol::Basic::ConsumeOk.superclass).to eq(Protocol::Method)
         end
 
         it "should have method name equal to basic.consume-ok" do
-          Protocol::Basic::ConsumeOk.name.should eql("basic.consume-ok")
+          expect(Protocol::Basic::ConsumeOk.name).to eql("basic.consume-ok")
         end
 
         it "has method id equal to 21" do
-          Protocol::Basic::ConsumeOk.method_id.should == 21
+          expect(Protocol::Basic::ConsumeOk.method_id).to eq(21)
         end
       end
 
       describe Protocol::Basic::Cancel do
         it "should be a subclass of Method" do
-          Protocol::Basic::Cancel.superclass.should == Protocol::Method
+          expect(Protocol::Basic::Cancel.superclass).to eq(Protocol::Method)
         end
 
         it "should have method name equal to basic.cancel" do
-          Protocol::Basic::Cancel.name.should eql("basic.cancel")
+          expect(Protocol::Basic::Cancel.name).to eql("basic.cancel")
         end
 
         it "has method id equal to 30" do
-          Protocol::Basic::Cancel.method_id.should == 30
+          expect(Protocol::Basic::Cancel.method_id).to eq(30)
         end
       end
 
       describe Protocol::Basic::CancelOk do
         it "should be a subclass of Method" do
-          Protocol::Basic::CancelOk.superclass.should == Protocol::Method
+          expect(Protocol::Basic::CancelOk.superclass).to eq(Protocol::Method)
         end
 
         it "should have method name equal to basic.cancel-ok" do
-          Protocol::Basic::CancelOk.name.should eql("basic.cancel-ok")
+          expect(Protocol::Basic::CancelOk.name).to eql("basic.cancel-ok")
         end
 
         it "has method id equal to 31" do
-          Protocol::Basic::CancelOk.method_id.should == 31
+          expect(Protocol::Basic::CancelOk.method_id).to eq(31)
         end
       end
 
       describe Protocol::Basic::Publish do
         it "should be a subclass of Method" do
-          Protocol::Basic::Publish.superclass.should == Protocol::Method
+          expect(Protocol::Basic::Publish.superclass).to eq(Protocol::Method)
         end
 
         it "should have method name equal to basic.publish" do
-          Protocol::Basic::Publish.name.should eql("basic.publish")
+          expect(Protocol::Basic::Publish.name).to eql("basic.publish")
         end
 
         it "has method id equal to 40" do
-          Protocol::Basic::Publish.method_id.should == 40
+          expect(Protocol::Basic::Publish.method_id).to eq(40)
         end
       end
 
       describe Protocol::Basic::Return do
         it "should be a subclass of Method" do
-          Protocol::Basic::Return.superclass.should == Protocol::Method
+          expect(Protocol::Basic::Return.superclass).to eq(Protocol::Method)
         end
 
         it "should have method name equal to basic.return" do
-          Protocol::Basic::Return.name.should eql("basic.return")
+          expect(Protocol::Basic::Return.name).to eql("basic.return")
         end
 
         it "has method id equal to 50" do
-          Protocol::Basic::Return.method_id.should == 50
+          expect(Protocol::Basic::Return.method_id).to eq(50)
         end
       end
 
       describe Protocol::Basic::Deliver do
         it "should be a subclass of Method" do
-          Protocol::Basic::Deliver.superclass.should == Protocol::Method
+          expect(Protocol::Basic::Deliver.superclass).to eq(Protocol::Method)
         end
 
         it "should have method name equal to basic.deliver" do
-          Protocol::Basic::Deliver.name.should eql("basic.deliver")
+          expect(Protocol::Basic::Deliver.name).to eql("basic.deliver")
         end
 
         it "has method id equal to 60" do
-          Protocol::Basic::Deliver.method_id.should == 60
+          expect(Protocol::Basic::Deliver.method_id).to eq(60)
         end
       end
 
       describe Protocol::Basic::Get do
         it "should be a subclass of Method" do
-          Protocol::Basic::Get.superclass.should == Protocol::Method
+          expect(Protocol::Basic::Get.superclass).to eq(Protocol::Method)
         end
 
         it "should have method name equal to basic.get" do
-          Protocol::Basic::Get.name.should eql("basic.get")
+          expect(Protocol::Basic::Get.name).to eql("basic.get")
         end
 
         it "has method id equal to 70" do
-          Protocol::Basic::Get.method_id.should == 70
+          expect(Protocol::Basic::Get.method_id).to eq(70)
         end
       end
 
       describe Protocol::Basic::GetOk do
         it "should be a subclass of Method" do
-          Protocol::Basic::GetOk.superclass.should == Protocol::Method
+          expect(Protocol::Basic::GetOk.superclass).to eq(Protocol::Method)
         end
 
         it "should have method name equal to basic.get-ok" do
-          Protocol::Basic::GetOk.name.should eql("basic.get-ok")
+          expect(Protocol::Basic::GetOk.name).to eql("basic.get-ok")
         end
 
         it "has method id equal to 71" do
-          Protocol::Basic::GetOk.method_id.should == 71
+          expect(Protocol::Basic::GetOk.method_id).to eq(71)
         end
       end
 
       describe Protocol::Basic::GetEmpty do
         it "should be a subclass of Method" do
-          Protocol::Basic::GetEmpty.superclass.should == Protocol::Method
+          expect(Protocol::Basic::GetEmpty.superclass).to eq(Protocol::Method)
         end
 
         it "should have method name equal to basic.get-empty" do
-          Protocol::Basic::GetEmpty.name.should eql("basic.get-empty")
+          expect(Protocol::Basic::GetEmpty.name).to eql("basic.get-empty")
         end
 
         it "has method id equal to 72" do
-          Protocol::Basic::GetEmpty.method_id.should == 72
+          expect(Protocol::Basic::GetEmpty.method_id).to eq(72)
         end
       end
 
       describe Protocol::Basic::Ack do
         it "should be a subclass of Method" do
-          Protocol::Basic::Ack.superclass.should == Protocol::Method
+          expect(Protocol::Basic::Ack.superclass).to eq(Protocol::Method)
         end
 
         it "should have method name equal to basic.ack" do
-          Protocol::Basic::Ack.name.should eql("basic.ack")
+          expect(Protocol::Basic::Ack.name).to eql("basic.ack")
         end
 
         it "has method id equal to 80" do
-          Protocol::Basic::Ack.method_id.should == 80
+          expect(Protocol::Basic::Ack.method_id).to eq(80)
         end
       end
 
       describe Protocol::Basic::Reject do
         it "should be a subclass of Method" do
-          Protocol::Basic::Reject.superclass.should == Protocol::Method
+          expect(Protocol::Basic::Reject.superclass).to eq(Protocol::Method)
         end
 
         it "should have method name equal to basic.reject" do
-          Protocol::Basic::Reject.name.should eql("basic.reject")
+          expect(Protocol::Basic::Reject.name).to eql("basic.reject")
         end
 
         it "has method id equal to 90" do
-          Protocol::Basic::Reject.method_id.should == 90
+          expect(Protocol::Basic::Reject.method_id).to eq(90)
         end
       end
 
       describe Protocol::Basic::RecoverAsync do
         it "should be a subclass of Method" do
-          Protocol::Basic::RecoverAsync.superclass.should == Protocol::Method
+          expect(Protocol::Basic::RecoverAsync.superclass).to eq(Protocol::Method)
         end
 
         it "should have method name equal to basic.recover-async" do
-          Protocol::Basic::RecoverAsync.name.should eql("basic.recover-async")
+          expect(Protocol::Basic::RecoverAsync.name).to eql("basic.recover-async")
         end
 
         it "has method id equal to 100" do
-          Protocol::Basic::RecoverAsync.method_id.should == 100
+          expect(Protocol::Basic::RecoverAsync.method_id).to eq(100)
         end
       end
 
       describe Protocol::Basic::Recover do
         it "should be a subclass of Method" do
-          Protocol::Basic::Recover.superclass.should == Protocol::Method
+          expect(Protocol::Basic::Recover.superclass).to eq(Protocol::Method)
         end
 
         it "should have method name equal to basic.recover" do
-          Protocol::Basic::Recover.name.should eql("basic.recover")
+          expect(Protocol::Basic::Recover.name).to eql("basic.recover")
         end
 
         it "has method id equal to 110" do
-          Protocol::Basic::Recover.method_id.should == 110
+          expect(Protocol::Basic::Recover.method_id).to eq(110)
         end
       end
 
       describe Protocol::Basic::RecoverOk do
         it "should be a subclass of Method" do
-          Protocol::Basic::RecoverOk.superclass.should == Protocol::Method
+          expect(Protocol::Basic::RecoverOk.superclass).to eq(Protocol::Method)
         end
 
         it "should have method name equal to basic.recover-ok" do
-          Protocol::Basic::RecoverOk.name.should eql("basic.recover-ok")
+          expect(Protocol::Basic::RecoverOk.name).to eql("basic.recover-ok")
         end
 
         it "has method id equal to 111" do
-          Protocol::Basic::RecoverOk.method_id.should == 111
+          expect(Protocol::Basic::RecoverOk.method_id).to eq(111)
         end
       end
     end

--- a/spec/amq/settings_spec.rb
+++ b/spec/amq/settings_spec.rb
@@ -6,20 +6,20 @@ require "amq/settings"
 describe AMQ::Settings do
   describe ".default" do
     it "should provide some default values" do
-      AMQ::Settings.default.should_not be_nil
-      AMQ::Settings.default[:host].should_not be_nil
+      expect(AMQ::Settings.default).to_not be_nil
+      expect(AMQ::Settings.default[:host]).to_not be_nil
     end
   end
 
   describe ".configure(&block)" do
     it "should merge custom settings with default settings" do
       settings = AMQ::Settings.configure(:host => "tagadab")
-      settings[:host].should eql("tagadab")
+      expect(settings[:host]).to eql("tagadab")
     end
 
     it "should merge custom settings from AMQP URL with default settings" do
       settings = AMQ::Settings.configure("amqp://tagadab")
-      settings[:host].should eql("tagadab")
+      expect(settings[:host]).to eql("tagadab")
     end
   end
 end

--- a/spec/amq/uri_parsing_spec.rb
+++ b/spec/amq/uri_parsing_spec.rb
@@ -16,21 +16,21 @@ describe AMQ::URI, ".parse" do
   it "handles amqp:// URIs w/o path part" do
     val = described_class.parse_amqp_url("amqp://dev.rabbitmq.com")
 
-    val[:vhost].should be_nil # in this case, default / will be used
-    val[:host].should == "dev.rabbitmq.com"
-    val[:port].should == 5672
-    val[:scheme].should == "amqp"
-    val[:ssl].should be_false
+    expect(val[:vhost]).to be_nil # in this case, default / will be used
+    expect(val[:host]).to eq("dev.rabbitmq.com")
+    expect(val[:port]).to eq(5672)
+    expect(val[:scheme]).to eq("amqp")
+    expect(val[:ssl]).to be_falsey
   end
 
   it "handles amqps:// URIs w/o path part" do
     val = described_class.parse_amqp_url("amqps://dev.rabbitmq.com")
 
-    val[:vhost].should be_nil
-    val[:host].should == "dev.rabbitmq.com"
-    val[:port].should == 5671
-    val[:scheme].should == "amqps"
-    val[:ssl].should be_true
+    expect(val[:vhost]).to be_nil
+    expect(val[:host]).to eq("dev.rabbitmq.com")
+    expect(val[:port]).to eq(5671)
+    expect(val[:scheme]).to eq("amqps")
+    expect(val[:ssl]).to be_truthy
   end
 
 
@@ -38,11 +38,11 @@ describe AMQ::URI, ".parse" do
     it "parses vhost as an empty string" do
       val = described_class.parse_amqp_url("amqp://dev.rabbitmq.com/")
 
-      val[:host].should == "dev.rabbitmq.com"
-      val[:port].should == 5672
-      val[:scheme].should == "amqp"
-      val[:ssl].should be_false
-      val[:vhost].should == ""
+      expect(val[:host]).to eq("dev.rabbitmq.com")
+      expect(val[:port]).to eq(5672)
+      expect(val[:scheme]).to eq("amqp")
+      expect(val[:ssl]).to be_falsey
+      expect(val[:vhost]).to eq("")
     end
   end
 
@@ -51,11 +51,11 @@ describe AMQ::URI, ".parse" do
     it "parses vhost as /vault" do
       val = described_class.parse_amqp_url("amqp://dev.rabbitmq.com/%2Fvault")
 
-      val[:host].should == "dev.rabbitmq.com"
-      val[:port].should == 5672
-      val[:scheme].should == "amqp"
-      val[:ssl].should be_false
-      val[:vhost].should == "/vault"
+      expect(val[:host]).to eq("dev.rabbitmq.com")
+      expect(val[:port]).to eq(5672)
+      expect(val[:scheme]).to eq("amqp")
+      expect(val[:ssl]).to be_falsey
+      expect(val[:vhost]).to eq("/vault")
     end
   end
 
@@ -64,17 +64,17 @@ describe AMQ::URI, ".parse" do
     it "parses vhost as a.path.without.slashes" do
       val = described_class.parse_amqp_url("amqp://dev.rabbitmq.com/a.path.without.slashes")
 
-      val[:host].should == "dev.rabbitmq.com"
-      val[:port].should == 5672
-      val[:scheme].should == "amqp"
-      val[:ssl].should be_false
-      val[:vhost].should == "a.path.without.slashes"
+      expect(val[:host]).to eq("dev.rabbitmq.com")
+      expect(val[:port]).to eq(5672)
+      expect(val[:scheme]).to eq("amqp")
+      expect(val[:ssl]).to be_falsey
+      expect(val[:vhost]).to eq("a.path.without.slashes")
     end
   end
 
   context "when URI is amqp://dev.rabbitmq.com/a/path/with/slashes" do
     it "raises an ArgumentError" do
-      lambda { described_class.parse_amqp_url("amqp://dev.rabbitmq.com/a/path/with/slashes") }.should raise_error(ArgumentError)
+      expect { described_class.parse_amqp_url("amqp://dev.rabbitmq.com/a/path/with/slashes") }.to raise_error(ArgumentError)
     end
   end
 
@@ -83,13 +83,13 @@ describe AMQ::URI, ".parse" do
     it "parses them out" do
       val = described_class.parse_amqp_url("amqp://hedgehog:t0ps3kr3t@hub.megacorp.internal")
 
-      val[:host].should == "hub.megacorp.internal"
-      val[:port].should == 5672
-      val[:scheme].should == "amqp"
-      val[:ssl].should be_false
-      val[:user].should == "hedgehog"
-      val[:pass].should == "t0ps3kr3t"
-      val[:vhost].should be_nil # in this case, default / will be used
+      expect(val[:host]).to eq("hub.megacorp.internal")
+      expect(val[:port]).to eq(5672)
+      expect(val[:scheme]).to eq("amqp")
+      expect(val[:ssl]).to be_falsey
+      expect(val[:user]).to eq("hedgehog")
+      expect(val[:pass]).to eq("t0ps3kr3t")
+      expect(val[:vhost]).to be_nil # in this case, default / will be used
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,6 +2,7 @@
 
 require 'bundler/setup'
 require 'rspec'
+require 'rspec/its'
 
 require "effin_utf8"
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -33,4 +33,6 @@ RSpec.configure do |config|
 
   config.include(RubyVersionsSupport)
   config.extend(RubyVersionsSupport)
+
+  config.warnings = true
 end


### PR DESCRIPTION
There a few failures remaining that I haven't resolved yet. I see them with both ruby 1.9.3-p392 and ruby 2.2.1, though there's an extra one with 1.9.3 Would love a hand.

The 1.9.3 failures
```
 1) AMQ::Protocol::Frame.encode should include final octet
     Failure/Error: expect(Frame.encode(:body, "test", 12).bytes.last).to eq("CE".hex)
     NoMethodError:
       undefined method `last' for #<Enumerator: "\x03\x00\f\x00\x00\x00\x04test\xCE":bytes>
     # ./spec/amq/protocol/frame_spec.rb:51:in `block (3 levels) in <module:Protocol>'
  2) AMQ::Protocol::Table.encode should serialize { :coordinates => { :latitude  => 59.35 } }
     Failure/Error: expect(Table.encode(:coordinates => { :latitude  => 59.35 })).to eql("\x00\x00\x00#\vcoordinatesF\x00\x00\x00\x12\blatituded@M\xAC\xCC\xCC\xCC\xCC\xCD")
       
       expected: "\u0000\u0000\u0000#\vcoordinatesF\u0000\u0000\u0000\u0012\blatituded@M\xAC\xCC\xCC\xCC\xCC\xCD"
            got: "\x00\x00\x00#\vcoordinatesF\x00\x00\x00\x12\blatituded@M\xAC\xCC\xCC\xCC\xCC\xCD"
       
       (compared using eql?)
     # ./spec/amq/protocol/table_spec.rb:61:in `block (3 levels) in <module:Protocol>'

  3) AMQ::Protocol::Table.encode should serialize { :coordinates => { :longitude => 18.066667 } }
     Failure/Error: expect(Table.encode(:coordinates => { :longitude => 18.066667 })).to eql("\x00\x00\x00$\vcoordinatesF\x00\x00\x00\x13\tlongituded@2\x11\x11\x16\xA8\xB8\xF1")
       
       expected: "\u0000\u0000\u0000$\vcoordinatesF\u0000\u0000\u0000\u0013\tlongituded@2\u0011\u0011\u0016\xA8\xB8\xF1"
            got: "\x00\x00\x00$\vcoordinatesF\x00\x00\x00\x13\tlongituded@2\x11\x11\x16\xA8\xB8\xF1"
       
       (compared using eql?)
     # ./spec/amq/protocol/table_spec.rb:65:in `block (3 levels) in <module:Protocol>'

  4) AMQ::Protocol::Table.encode should return "\u0000\u0000\u0000\u000F\u0005floatd?\xFE\xB8Q\xEB\x85\u001E\xB8" for {"float"=>1.92}
     Failure/Error: expect(Table.encode(data)).to eql(encoded)
       
       expected: "\u0000\u0000\u0000\u000F\u0005floatd?\xFE\xB8Q\xEB\x85\u001E\xB8"
            got: "\x00\x00\x00\x0F\x05floatd?\xFE\xB8Q\xEB\x85\x1E\xB8"
       
       (compared using eql?)
     # ./spec/amq/protocol/table_spec.rb:70:in `block (4 levels) in <module:Protocol>'

  5) AMQ::Protocol::Table.decode is capable of decoding string table values with UTF-8 characters
     Failure/Error: expect(Table.decode(Table.encode(input))).to eq(input)
     ArgumentError:
       Not a valid type: "?"
       Data: "\u0000\u0000\u0000\"\f??????S\u0000\u0000\u0000\u0010????????"
       Unprocessed data: "??????"
       Offset: 18
       Total size: 34
       Processed data: {}
     # ./lib/amq/protocol/table.rb:105:in `decode'
     # ./spec/amq/protocol/table_spec.rb:114:in `block (3 levels) in <module:Protocol>'

  6) AMQ::Protocol::Table.decode is capable of decoding deeply nested tables
     Failure/Error: expect(Table.decode(Table.encode(input))).to eq(input)
     Encoding::CompatibilityError:
       incompatible character encodings: ASCII-8BIT and UTF-8
     # ./lib/amq/protocol/table.rb:42:in `block in encode'
     # ./lib/amq/protocol/table.rb:35:in `each'
     # ./lib/amq/protocol/table.rb:35:in `encode'
     # ./lib/amq/protocol/table.rb:42:in `block in encode'
     # ./lib/amq/protocol/table.rb:35:in `each'
     # ./lib/amq/protocol/table.rb:35:in `encode'
     # ./lib/amq/protocol/table.rb:42:in `block in encode'
     # ./lib/amq/protocol/table.rb:35:in `each'
     # ./lib/amq/protocol/table.rb:35:in `encode'
     # ./spec/amq/protocol/table_spec.rb:221:in `block (3 levels) in <module:Protocol>'

Finished in 0.1339 seconds (files took 0.28567 seconds to load)
412 examples, 6 failures

Failed examples:

rspec ./spec/amq/protocol/frame_spec.rb:50 # AMQ::Protocol::Frame.encode should include final octet
rspec ./spec/amq/protocol/table_spec.rb:60 # AMQ::Protocol::Table.encode should serialize { :coordinates => { :latitude  => 59.35 } }
rspec ./spec/amq/protocol/table_spec.rb:64 # AMQ::Protocol::Table.encode should serialize { :coordinates => { :longitude => 18.066667 } }
rspec ./spec/amq/protocol/table_spec.rb:69 # AMQ::Protocol::Table.encode should return "\u0000\u0000\u0000\u000F\u0005floatd?\xFE\xB8Q\xEB\x85\u001E\xB8" for {"float"=>1.92}
rspec ./spec/amq/protocol/table_spec.rb:112 # AMQ::Protocol::Table.decode is capable of decoding string table values with UTF-8 characters
rspec ./spec/amq/protocol/table_spec.rb:203 # AMQ::Protocol::Table.decode is capable of decoding deeply nested tables
```

The failures in 2.2.1:
```
  1) AMQ::Protocol::Table.encode should serialize { :coordinates => { :latitude  => 59.35 } }
     Failure/Error: expect(Table.encode(:coordinates => { :latitude  => 59.35 })).to eql("\x00\x00\x00#\vcoordinatesF\x00\x00\x00\x12\blatituded@M\xAC\xCC\xCC\xCC\xCC\xCD")
       
       expected: "\u0000\u0000\u0000#\vcoordinatesF\u0000\u0000\u0000\u0012\blatituded@M\xAC\xCC\xCC\xCC\xCC\xCD"
            got: "\x00\x00\x00#\vcoordinatesF\x00\x00\x00\x12\blatituded@M\xAC\xCC\xCC\xCC\xCC\xCD"
       
       (compared using eql?)
     # ./spec/amq/protocol/table_spec.rb:61:in `block (3 levels) in <module:Protocol>'

  2) AMQ::Protocol::Table.encode should serialize { :coordinates => { :longitude => 18.066667 } }
     Failure/Error: expect(Table.encode(:coordinates => { :longitude => 18.066667 })).to eql("\x00\x00\x00$\vcoordinatesF\x00\x00\x00\x13\tlongituded@2\x11\x11\x16\xA8\xB8\xF1")
       
       expected: "\u0000\u0000\u0000$\vcoordinatesF\u0000\u0000\u0000\u0013\tlongituded@2\u0011\u0011\u0016\xA8\xB8\xF1"
            got: "\x00\x00\x00$\vcoordinatesF\x00\x00\x00\x13\tlongituded@2\x11\x11\x16\xA8\xB8\xF1"
       
       (compared using eql?)
     # ./spec/amq/protocol/table_spec.rb:65:in `block (3 levels) in <module:Protocol>'

  3) AMQ::Protocol::Table.encode should return "\u0000\u0000\u0000\u000F\u0005floatd?\xFE\xB8Q\xEB\x85\u001E\xB8" for {"float"=>1.92}
     Failure/Error: expect(Table.encode(data)).to eql(encoded)
       
       expected: "\u0000\u0000\u0000\u000F\u0005floatd?\xFE\xB8Q\xEB\x85\u001E\xB8"
            got: "\x00\x00\x00\x0F\x05floatd?\xFE\xB8Q\xEB\x85\x1E\xB8"
       
       (compared using eql?)
     # ./spec/amq/protocol/table_spec.rb:70:in `block (4 levels) in <module:Protocol>'

  4) AMQ::Protocol::Table.decode is capable of decoding string table values with UTF-8 characters
     Failure/Error: expect(Table.decode(Table.encode(input))).to eq(input)
     ArgumentError:
       Not a valid type: "н"
       Data: "\u0000\u0000\u0000\"\fстрокаS\u0000\u0000\u0000\u0010значение"
       Unprocessed data: "ачение"
       Offset: 18
       Total size: 34
       Processed data: {}
     # ./lib/amq/protocol/table.rb:105:in `decode'
     # ./spec/amq/protocol/table_spec.rb:114:in `block (3 levels) in <module:Protocol>'

  5) AMQ::Protocol::Table.decode is capable of decoding deeply nested tables
     Failure/Error: expect(Table.decode(Table.encode(input))).to eq(input)
     Encoding::CompatibilityError:
       incompatible character encodings: ASCII-8BIT and UTF-8
     # ./lib/amq/protocol/table.rb:42:in `block in encode'
     # ./lib/amq/protocol/table.rb:35:in `each'
     # ./lib/amq/protocol/table.rb:35:in `encode'
     # ./lib/amq/protocol/table.rb:42:in `block in encode'
     # ./lib/amq/protocol/table.rb:35:in `each'
     # ./lib/amq/protocol/table.rb:35:in `encode'
     # ./lib/amq/protocol/table.rb:42:in `block in encode'
     # ./lib/amq/protocol/table.rb:35:in `each'
     # ./lib/amq/protocol/table.rb:35:in `encode'
     # ./spec/amq/protocol/table_spec.rb:221:in `block (3 levels) in <module:Protocol>'

Finished in 0.11542 seconds (files took 0.20092 seconds to load)
412 examples, 5 failures

Failed examples:

rspec ./spec/amq/protocol/table_spec.rb:60 # AMQ::Protocol::Table.encode should serialize { :coordinates => { :latitude  => 59.35 } }
rspec ./spec/amq/protocol/table_spec.rb:64 # AMQ::Protocol::Table.encode should serialize { :coordinates => { :longitude => 18.066667 } }
rspec ./spec/amq/protocol/table_spec.rb:69 # AMQ::Protocol::Table.encode should return "\u0000\u0000\u0000\u000F\u0005floatd?\xFE\xB8Q\xEB\x85\u001E\xB8" for {"float"=>1.92}
rspec ./spec/amq/protocol/table_spec.rb:112 # AMQ::Protocol::Table.decode is capable of decoding string table values with UTF-8 characters
rspec ./spec/amq/protocol/table_spec.rb:203 # AMQ::Protocol::Table.decode is capable of decoding deeply nested tables
```




