### PR TITLE
Fix #30 (headers encoding other than ASCII-8BIT)

### DIFF
--- a/lib/amq/protocol/client.rb
+++ b/lib/amq/protocol/client.rb
@@ -1437,7 +1437,8 @@ module AMQ
         result = [60, 0].pack(PACK_UINT16_X2)
         result += AMQ::Pack.pack_uint64_big_endian(body_size)
         result += [flags].pack(PACK_UINT16)
-        result + pieces.join(EMPTY_STRING)
+        pieces_joined = pieces.join(EMPTY_STRING)
+        result.force_encoding(pieces_joined.encoding) + pieces_joined
       end
 
       # THIS DECODES ONLY FLAGS


### PR DESCRIPTION
see comments at: https://github.com/ruby-amqp/amq-protocol/issues/30#issuecomment-159605982
