### PR TITLE
Parse URI Query Parameters

### DIFF
--- a/lib/amq/uri.rb
+++ b/lib/amq/uri.rb
@@ -8,12 +8,23 @@ module AMQ
     # @private
     AMQP_PORTS = {"amqp" => 5672, "amqps" => 5671}.freeze
 
+    DEFAULTS = {
+      heartbeat: nil,
+      connection_timeout: nil,
+      channel_max: nil,
+      auth_mechanism: [],
+      verify: false,
+      fail_if_no_peer_cert: false,
+      cacertfile: nil,
+      certfile: nil,
+      keyfile: nil
+    }.freeze
 
     def self.parse(connection_string)
       uri = ::URI.parse(connection_string)
       raise ArgumentError.new("Connection URI must use amqp or amqps schema (example: amqp://bus.megacorp.internal:5766), learn more at http://bit.ly/ks8MXK") unless %w{amqp amqps}.include?(uri.scheme)
 
-      opts = {}
+      opts = DEFAULTS.dup
 
       opts[:scheme] = uri.scheme
       opts[:user]   = ::CGI::unescape(uri.user) if uri.user
@@ -26,8 +37,28 @@ module AMQ
         opts[:vhost] = ::CGI::unescape($1)
       end
 
+      if uri.query
+        query_params = CGI::parse(uri.query)
+
+        normalized_query_params = Hash[query_params.map { |param, value| [param, value.one? ? value.first : value] }]
+
+        opts[:heartbeat] = normalized_query_params["heartbeat"].to_i
+        opts[:connection_timeout] = normalized_query_params["connection_timeout"].to_i
+        opts[:channel_max] = normalized_query_params["channel_max"].to_i
+        opts[:auth_mechanism] = normalized_query_params["auth_mechanism"]
+
+        %w(verify fail_if_no_peer_cert cacertfile certfile keyfile).each do |ssl_option|
+          if normalized_query_params[ssl_option] && uri.scheme == "amqp"
+            raise ArgumentError.new("Only of use for the amqps scheme")
+          else
+            opts[ssl_option.to_sym] = normalized_query_params[ssl_option]
+          end
+        end
+      end
+
       opts
     end
+
     def self.parse_amqp_url(s)
       parse(s)
     end


### PR DESCRIPTION
PR for #66 

So here is the `AMQ::URI.parse` method extension for query parameters. This is a prototype code that I'd like to polish after main ideas agreement:
• Introduce `DEFAULTS` constant to keep them as some kind of declaration
• Raise `ArgumentError` for ssl/tls parameters along with `amqp` schema
• Some concerns about `URI` and `CGI` usage. I'm not so keen on this libraries to understand what should help us escape and parse properly. Could somebody give insight regarding this?

@michaelklishin, do you like such nested structure of the contexts in the specs? I noticed you don't compose contexts and prefer to interpolate `"when ...` inside example description. If you find such approach more flexible and expressive, I'd happy to adjust existing specs in `uri_parsing_spec.rb` file to the same look.