### PR TITLE
Refactor URI Parsing Spec

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,3 +1,1 @@
---colour
---format
-progress
+--require spec_helper

--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ group :development do
 end
 
 group :test do
-  gem "rspec", ">= 3.4.0"
+  gem "rspec", ">= 3.5.0"
   gem "rspec-its"
   gem "effin_utf8"
 end

--- a/Gemfile
+++ b/Gemfile
@@ -14,3 +14,7 @@ group :test do
   gem "rspec-its"
   gem "effin_utf8"
 end
+
+group :development, :test do
+  gem "byebug"
+end

--- a/Gemfile
+++ b/Gemfile
@@ -13,6 +13,7 @@ group :test do
   gem "rspec", ">= 3.5.0"
   gem "rspec-its"
   gem "effin_utf8"
+  gem "simplecov"
 end
 
 group :development, :test do

--- a/lib/amq/uri.rb
+++ b/lib/amq/uri.rb
@@ -31,7 +31,7 @@ module AMQ
       opts[:pass]   = ::CGI::unescape(uri.password) if uri.password
       opts[:host]   = uri.host if uri.host
       opts[:port]   = uri.port || AMQP_PORTS[uri.scheme]
-      opts[:ssl]    = uri.scheme.to_s.downcase =~ /amqps/i
+      opts[:ssl]    = uri.scheme.to_s.downcase =~ /amqps/i # TODO: rename to tls
       if uri.path =~ %r{^/(.*)}
         raise ArgumentError.new("#{uri} has multiple-segment path; please percent-encode any slashes in the vhost name (e.g. /production => %2Fproduction). Learn more at http://bit.ly/amqp-gem-and-connection-uris") if $1.index('/')
         opts[:vhost] = ::CGI::unescape($1)
@@ -49,7 +49,7 @@ module AMQ
 
         %w(verify fail_if_no_peer_cert cacertfile certfile keyfile).each do |tls_option|
           if normalized_query_params[tls_option] && uri.scheme == "amqp"
-            raise ArgumentError.new("The option '#{tls_option}' can only be used in URIs that use amqps for schema")
+            raise ArgumentError.new("The option '#{tls_option}' can only be used in URIs that use amqps schema")
           else
             opts[tls_option.to_sym] = normalized_query_params[tls_option]
           end

--- a/spec/amq/bit_set_spec.rb
+++ b/spec/amq/bit_set_spec.rb
@@ -4,7 +4,7 @@ require "amq/bit_set"
 
 
 # extracted from amqp gem. MK.
-describe AMQ::BitSet do
+RSpec.describe AMQ::BitSet do
 
   #
   # Environment

--- a/spec/amq/bit_set_spec.rb
+++ b/spec/amq/bit_set_spec.rb
@@ -1,7 +1,5 @@
 # encoding: utf-8
 
-require 'spec_helper'
-
 require "amq/bit_set"
 
 

--- a/spec/amq/bit_set_spec.rb
+++ b/spec/amq/bit_set_spec.rb
@@ -1,7 +1,4 @@
-# encoding: utf-8
-
 require "amq/bit_set"
-
 
 # extracted from amqp gem. MK.
 RSpec.describe AMQ::BitSet do

--- a/spec/amq/int_allocator_spec.rb
+++ b/spec/amq/int_allocator_spec.rb
@@ -2,7 +2,7 @@
 
 require "amq/int_allocator"
 
-describe AMQ::IntAllocator do
+RSpec.describe AMQ::IntAllocator do
 
   #
   # Environment

--- a/spec/amq/int_allocator_spec.rb
+++ b/spec/amq/int_allocator_spec.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 require "amq/int_allocator"
 
 RSpec.describe AMQ::IntAllocator do

--- a/spec/amq/int_allocator_spec.rb
+++ b/spec/amq/int_allocator_spec.rb
@@ -1,6 +1,5 @@
 # encoding: utf-8
 
-require 'spec_helper'
 require "amq/int_allocator"
 
 describe AMQ::IntAllocator do

--- a/spec/amq/pack_spec.rb
+++ b/spec/amq/pack_spec.rb
@@ -1,74 +1,68 @@
 # encoding: binary
 
-
-module AMQ
-  describe Pack do
-    context "16-bit big-endian packing / unpacking" do
-      let(:examples_16bit) {
-        {
-            0x068D => "\x06\x8D" # 1677
-        }
+RSpec.describe AMQ::Pack do
+  context "16-bit big-endian packing / unpacking" do
+    let(:examples_16bit) {
+      {
+          0x068D => "\x06\x8D" # 1677
       }
+    }
 
-      it "unpacks signed integers from a string to a number" do
-        examples_16bit.each do |key, value|
-          expect(described_class.unpack_int16_big_endian(value)[0]).to eq(key)
-        end
+    it "unpacks signed integers from a string to a number" do
+      examples_16bit.each do |key, value|
+        expect(described_class.unpack_int16_big_endian(value)[0]).to eq(key)
+      end
+    end
+  end
+
+  context "64-bit big-endian packing / unpacking" do
+    let(:examples) {
+      {
+        0x0000000000000000 => "\x00\x00\x00\x00\x00\x00\x00\x00",
+        0x000000000000000A => "\x00\x00\x00\x00\x00\x00\x00\x0A",
+        0x00000000000000A0 => "\x00\x00\x00\x00\x00\x00\x00\xA0",
+        0x000000000000B0A0 => "\x00\x00\x00\x00\x00\x00\xB0\xA0",
+        0x00000000000CB0AD => "\x00\x00\x00\x00\x00\x0C\xB0\xAD",
+        0x8BADF00DDEFEC8ED => "\x8B\xAD\xF0\x0D\xDE\xFE\xC8\xED",
+        0x0D15EA5EFEE1DEAD => "\x0D\x15\xEA\x5E\xFE\xE1\xDE\xAD",
+        0xDEADBEEFDEADBABE => "\xDE\xAD\xBE\xEF\xDE\xAD\xBA\xBE"
+      }
+    }
+
+    it "packs integers into big-endian string" do
+      examples.each do |key, value|
+        expect(described_class.pack_uint64_big_endian(key)).to eq(value)
       end
     end
 
-
-
-    context "64-bit big-endian packing / unpacking" do
-      let(:examples) {
-        {
-          0x0000000000000000 => "\x00\x00\x00\x00\x00\x00\x00\x00",
-          0x000000000000000A => "\x00\x00\x00\x00\x00\x00\x00\x0A",
-          0x00000000000000A0 => "\x00\x00\x00\x00\x00\x00\x00\xA0",
-          0x000000000000B0A0 => "\x00\x00\x00\x00\x00\x00\xB0\xA0",
-          0x00000000000CB0AD => "\x00\x00\x00\x00\x00\x0C\xB0\xAD",
-          0x8BADF00DDEFEC8ED => "\x8B\xAD\xF0\x0D\xDE\xFE\xC8\xED",
-          0x0D15EA5EFEE1DEAD => "\x0D\x15\xEA\x5E\xFE\xE1\xDE\xAD",
-          0xDEADBEEFDEADBABE => "\xDE\xAD\xBE\xEF\xDE\xAD\xBA\xBE"
-        }
-      }
-
-      it "packs integers into big-endian string" do
-        examples.each do |key, value|
-          expect(described_class.pack_uint64_big_endian(key)).to eq(value)
-        end
+    it "should unpack string representation into integer" do
+      examples.each do |key, value|
+        expect(described_class.unpack_uint64_big_endian(value)[0]).to eq(key)
       end
+    end
 
-      it "should unpack string representation into integer" do
-        examples.each do |key, value|
-          expect(described_class.unpack_uint64_big_endian(value)[0]).to eq(key)
+    if RUBY_VERSION < '1.9'
+      describe "with utf encoding" do
+        before do
+          $KCODE = 'u'
         end
-      end
 
-      if RUBY_VERSION < '1.9'
-        describe "with utf encoding" do
-          before do
-            $KCODE = 'u'
+        after do
+          $KCODE = 'NONE'
+        end
+
+        it "packs integers into big-endian string" do
+          examples.each do |key, value|
+            expect(described_class.pack_uint64_big_endian(key)).to eq(value)
           end
+        end
 
-          after do
-            $KCODE = 'NONE'
-          end
-
-          it "packs integers into big-endian string" do
-            examples.each do |key, value|
-              expect(described_class.pack_uint64_big_endian(key)).to eq(value)
-            end
-          end
-
-          it "should unpack string representation into integer" do
-            examples.each do |key, value|
-              expect(described_class.unpack_uint64_big_endian(value)[0]).to eq(key)
-            end
+        it "should unpack string representation into integer" do
+          examples.each do |key, value|
+            expect(described_class.unpack_uint64_big_endian(value)[0]).to eq(key)
           end
         end
       end
-
     end
   end
 end

--- a/spec/amq/pack_spec.rb
+++ b/spec/amq/pack_spec.rb
@@ -1,7 +1,5 @@
 # encoding: binary
 
-require File.expand_path('../../spec_helper', __FILE__)
-
 
 module AMQ
   describe Pack do

--- a/spec/amq/protocol/basic_spec.rb
+++ b/spec/amq/protocol/basic_spec.rb
@@ -1,40 +1,39 @@
 # encoding: binary
 
-
 module AMQ
   module Protocol
-    describe Basic do
+    RSpec.describe AMQ::Protocol::Basic do
       describe '.encode_timestamp' do
         it 'encodes the timestamp as a 64 byte big endian integer' do
           expect(Basic.encode_timestamp(12345).last).to eq("\x00\x00\x00\x00\x00\x0009")
         end
       end
-      
+
       # describe '.decode_timestamp' do
       #   it 'decodes the timestamp from a 64 byte big endian integer and returns a Time object' do
       #     expect(Basic.decode_timestamp("\x00\x00\x00\x00\x00\x0009")).to eq(Time.at(12345))
       #   end
       # end
-      
+
       describe '.encode_headers' do
         it 'encodes the headers as a table' do
           expect(Basic.encode_headers(:hello => 'world').last).to eq("\x00\x00\x00\x10\x05helloS\x00\x00\x00\x05world")
         end
       end
-      
+
       # describe '.decode_headers' do
       #   it 'decodes the headers from a table' do
       #     expect(Basic.decode_headers("\x00\x00\x00\x10\x05helloS\x00\x00\x00\x05world")).to eq({'hello' => 'world'})
       #   end
       # end
-      
+
       describe '.encode_properties' do
         it 'packs the parameters into a byte array using the other encode_* methods' do
           result = Basic.encode_properties(10, {:priority => 0, :delivery_mode => 2, :content_type => 'application/octet-stream'})
           expect(result).to eq("\x00<\x00\x00\x00\x00\x00\x00\x00\x00\x00\x0a\x98\x00\x18application/octet-stream\x02\x00")
         end
       end
-      
+
       describe '.decode_properties' do
         it 'unpacks the properties from a byte array using the decode_* methods' do
           result = Basic.decode_properties("\x98@\x18application/octet-stream\x02\x00\x00\x00\x00\x00\x00\x00\x00{")
@@ -46,7 +45,7 @@ module AMQ
           expect(result).to eq({:priority => 0, :delivery_mode => 2, :content_type => 'application/octet-stream', :timestamp => Time.at(123), :headers => {'hello' => 'world'}})
         end
       end
-      
+
       %w(content_type content_encoding correlation_id reply_to expiration message_id type user_id app_id cluster_id).each do |method|
         describe ".encode_#{method}" do
           it 'encodes the parameter as a Pascal string' do
@@ -61,7 +60,7 @@ module AMQ
         #   end
         # end
       end
-      
+
       %w(delivery_mode priority).each do |method|
         describe ".encode_#{method}" do
           it 'encodes the parameter as a char' do
@@ -76,9 +75,9 @@ module AMQ
         # end
       end
     end
-    
+
     class Basic
-      describe Qos do
+      RSpec.describe Qos do
         describe '.encode' do
           it 'encodes the parameters into a MethodFrame' do
             channel = 1
@@ -92,12 +91,12 @@ module AMQ
         end
       end
 
-      # describe QosOk do
+      # RSpec.describe QosOk do
       #   describe '.decode' do
       #   end
       # end
 
-      describe Consume do
+      RSpec.describe Consume do
         describe '.encode' do
           it 'encodes the parameters into a MethodFrame' do
             channel = 1
@@ -114,18 +113,18 @@ module AMQ
           end
         end
       end
-      
-      describe ConsumeOk do
+
+      RSpec.describe ConsumeOk do
         describe '.decode' do
           subject do
             ConsumeOk.decode("\x03foo")
           end
-          
+
           its(:consumer_tag) { should eq('foo') }
         end
       end
 
-      describe Cancel do
+      RSpec.describe Cancel do
         describe '.encode' do
           it 'encodes the parameters into a MethodFrame' do
             channel = 1
@@ -136,27 +135,27 @@ module AMQ
             expect(method_frame.channel).to eq(1)
           end
         end
-        
+
         describe '.decode' do
           subject do
-            CancelOk.decode("\x03foo\x01")            
+            CancelOk.decode("\x03foo\x01")
           end
 
           its(:consumer_tag) { should eq('foo') }
         end
       end
 
-      describe CancelOk do
+      RSpec.describe CancelOk do
         describe '.decode' do
           subject do
             CancelOk.decode("\x03foo")
           end
-          
+
           its(:consumer_tag) { should eq('foo') }
         end
       end
 
-      describe Publish do
+      RSpec.describe Publish do
         describe '.encode' do
           it 'encodes the parameters into a list of MethodFrames' do
             channel = 1
@@ -179,12 +178,12 @@ module AMQ
         end
       end
 
-      describe Return do
+      RSpec.describe Return do
         describe '.decode' do
           subject do
             Return.decode("\x019\fNO_CONSUMERS\namq.fanout\x00")
           end
-          
+
           its(:reply_code) { should eq(313) }
           its(:reply_text) { should eq('NO_CONSUMERS') }
           its(:exchange) { should eq('amq.fanout') }
@@ -192,12 +191,12 @@ module AMQ
         end
       end
 
-      describe Deliver do
+      RSpec.describe Deliver do
         describe '.decode' do
           subject do
             Deliver.decode("\e-1300560114000-445586772970\x00\x00\x00\x00\x00\x00\x00c\x00\namq.fanout\x00")
           end
-          
+
           its(:consumer_tag) { should eq('-1300560114000-445586772970') }
           its(:delivery_tag) { should eq(99) }
           its(:redelivered) { should eq(false) }
@@ -205,8 +204,8 @@ module AMQ
           its(:routing_key) { should eq('') }
         end
       end
-      
-      describe Get do
+
+      RSpec.describe Get do
         describe '.encode' do
           it 'encodes the parameters into a MethodFrame' do
             channel = 1
@@ -218,13 +217,13 @@ module AMQ
           end
         end
       end
-      
-      describe GetOk do
+
+      RSpec.describe GetOk do
         describe '.decode' do
           subject do
             GetOk.decode("\x00\x00\x00\x00\x00\x00\x00\x06\x00\namq.fanout\x00\x00\x00\x00^")
           end
-          
+
           its(:delivery_tag) { should eq(6) }
           its(:redelivered) { should eq(false) }
           its(:exchange) { should eq('amq.fanout') }
@@ -232,18 +231,18 @@ module AMQ
           its(:message_count) { should eq(94) }
         end
       end
-      
-      describe GetEmpty do
+
+      RSpec.describe GetEmpty do
         describe '.decode' do
           subject do
             GetEmpty.decode("\x03foo")
           end
-          
+
           its(:cluster_id) { should eq('foo') }
         end
       end
 
-      describe Ack do
+      RSpec.describe Ack do
         describe '.encode' do
           it 'encodes the parameters into a MethodFrame' do
             channel = 1
@@ -255,8 +254,8 @@ module AMQ
           end
         end
       end
-      
-      describe Reject do
+
+      RSpec.describe Reject do
         describe '.encode' do
           it 'encodes the parameters into a MethodFrame' do
             channel = 1
@@ -268,8 +267,8 @@ module AMQ
           end
         end
       end
-      
-      describe RecoverAsync do
+
+      RSpec.describe RecoverAsync do
         describe '.encode' do
           it 'encodes the parameters into a MethodFrame' do
             channel = 1
@@ -280,8 +279,8 @@ module AMQ
           end
         end
       end
-      
-      describe Recover do
+
+      RSpec.describe Recover do
         describe '.encode' do
           it 'encodes the parameters into a MethodFrame' do
             channel = 1
@@ -293,22 +292,22 @@ module AMQ
         end
       end
 
-      # describe RecoverOk do
+      # RSpec.describe RecoverOk do
       #   describe '.decode' do
       #   end
       # end
-      
-      describe Nack do
+
+      RSpec.describe Nack do
         describe '.decode' do
           subject do
             Nack.decode("\x00\x00\x00\x00\x00\x00\x00\x09\x03")
           end
-          
+
           its(:delivery_tag) { should eq(9) }
           its(:multiple) { should eq(true) }
           its(:requeue) { should eq(true) }
         end
-        
+
         describe '.encode' do
           it 'encodes the parameters into a MethodFrame' do
             channel = 1

--- a/spec/amq/protocol/basic_spec.rb
+++ b/spec/amq/protocol/basic_spec.rb
@@ -1,7 +1,5 @@
 # encoding: binary
 
-require File.expand_path('../../../spec_helper', __FILE__)
-
 
 module AMQ
   module Protocol

--- a/spec/amq/protocol/blank_body_encoding_spec.rb
+++ b/spec/amq/protocol/blank_body_encoding_spec.rb
@@ -1,6 +1,3 @@
-# encoding: binary
-
-
 RSpec.describe AMQ::Protocol::Method, ".encode_body" do
   it "encodes 1-byte long payload as exactly 1 body frame" do
     expect(described_class.encode_body('1', 1, 65536).size).to eq(1)

--- a/spec/amq/protocol/blank_body_encoding_spec.rb
+++ b/spec/amq/protocol/blank_body_encoding_spec.rb
@@ -1,7 +1,7 @@
 # encoding: binary
 
 
-describe AMQ::Protocol::Method, ".encode_body" do
+RSpec.describe AMQ::Protocol::Method, ".encode_body" do
   it "encodes 1-byte long payload as exactly 1 body frame" do
     expect(described_class.encode_body('1', 1, 65536).size).to eq(1)
   end

--- a/spec/amq/protocol/blank_body_encoding_spec.rb
+++ b/spec/amq/protocol/blank_body_encoding_spec.rb
@@ -1,7 +1,5 @@
 # encoding: binary
 
-require File.expand_path('../../../spec_helper', __FILE__)
-
 
 describe AMQ::Protocol::Method, ".encode_body" do
   it "encodes 1-byte long payload as exactly 1 body frame" do

--- a/spec/amq/protocol/channel_spec.rb
+++ b/spec/amq/protocol/channel_spec.rb
@@ -1,10 +1,9 @@
 # encoding: binary
 
-
 module AMQ
   module Protocol
     class Channel
-      describe Open do
+      RSpec.describe Open do
         describe '.encode' do
           it 'encodes the parameters into a MethodFrame' do
             channel = 1
@@ -16,7 +15,7 @@ module AMQ
         end
       end
 
-      describe OpenOk do
+      RSpec.describe OpenOk do
         describe '.decode' do
           subject do
             OpenOk.decode("\x00\x00\x00\x03foo")
@@ -26,7 +25,7 @@ module AMQ
         end
       end
 
-      describe Flow do
+      RSpec.describe Flow do
         describe '.decode' do
           subject do
             Flow.decode("\x01")
@@ -46,7 +45,7 @@ module AMQ
         end
       end
 
-      describe FlowOk do
+      RSpec.describe FlowOk do
         describe '.decode' do
           subject do
             FlowOk.decode("\x00")
@@ -66,7 +65,7 @@ module AMQ
         end
       end
 
-      describe Close do
+      RSpec.describe Close do
         describe '.decode' do
           context 'with code 200' do
             subject do
@@ -113,7 +112,7 @@ module AMQ
         end
       end
 
-      describe CloseOk do
+      RSpec.describe CloseOk do
         describe '.encode' do
           it 'encodes the parameters into a MethodFrame' do
             channel = 1

--- a/spec/amq/protocol/channel_spec.rb
+++ b/spec/amq/protocol/channel_spec.rb
@@ -1,7 +1,5 @@
 # encoding: binary
 
-require File.expand_path('../../../spec_helper', __FILE__)
-
 
 module AMQ
   module Protocol

--- a/spec/amq/protocol/confirm_spec.rb
+++ b/spec/amq/protocol/confirm_spec.rb
@@ -1,18 +1,17 @@
 # encoding: binary
 
-
 module AMQ
   module Protocol
     class Confirm
-      describe Select do
+      RSpec.describe Select do
         describe '.decode' do
           subject do
             Select.decode("\x01")
           end
-          
+
           its(:nowait) { should be_truthy }
         end
-        
+
         describe '.encode' do
           it 'encodes the parameters into a MethodFrame' do
             channel = 1
@@ -23,11 +22,11 @@ module AMQ
           end
         end
       end
-      
-      describe SelectOk do
+
+      RSpec.describe SelectOk do
         # describe '.decode' do
         # end
-        
+
         describe '.encode' do
           it 'encodes the parameters into a MethodFrame' do
             channel = 1

--- a/spec/amq/protocol/confirm_spec.rb
+++ b/spec/amq/protocol/confirm_spec.rb
@@ -1,7 +1,5 @@
 # encoding: binary
 
-require File.expand_path('../../../spec_helper', __FILE__)
-
 
 module AMQ
   module Protocol

--- a/spec/amq/protocol/connection_spec.rb
+++ b/spec/amq/protocol/connection_spec.rb
@@ -1,10 +1,9 @@
 # encoding: binary
 
-
 module AMQ
   module Protocol
     class Connection
-      describe Start do
+      RSpec.describe Start do
         describe '.decode' do
           subject do
             Start.decode("\x00\t\x00\x00\x00\xFB\tcopyrightS\x00\x00\x00gCopyright (C) 2007-2010 LShift Ltd., Cohesive Financial Technologies LLC., and Rabbit Technologies Ltd.\vinformationS\x00\x00\x005Licensed under the MPL.  See http://www.rabbitmq.com/\bplatformS\x00\x00\x00\nErlang/OTP\aproductS\x00\x00\x00\bRabbitMQ\aversionS\x00\x00\x00\x052.2.0\x00\x00\x00\x0EPLAIN AMQPLAIN\x00\x00\x00\x05en_US")
@@ -18,7 +17,7 @@ module AMQ
         end
       end
 
-      describe StartOk do
+      RSpec.describe StartOk do
         describe '.encode' do
           it 'encodes the parameters into a MethodFrame' do
             client_properties = {:platform => 'Ruby 1.9.2', :product => 'AMQ Client', :information => 'http://github.com/ruby-amqp/amq-client', :version => '0.2.0'}
@@ -37,18 +36,18 @@ module AMQ
           end
         end
       end
-      
-      describe Secure do
+
+      RSpec.describe Secure do
         describe '.decode' do
           subject do
             Secure.decode("\x00\x00\x00\x03foo")
           end
-          
+
           its(:challenge) { should eq('foo') }
         end
       end
-    
-      describe SecureOk do
+
+      RSpec.describe SecureOk do
         describe '.encode' do
           it 'encodes the parameters as a MethodFrame' do
             response = 'bar'
@@ -57,8 +56,8 @@ module AMQ
           end
         end
       end
-    
-      describe Tune do
+
+      RSpec.describe Tune do
         describe '.decode' do
           subject do
             Tune.decode("\x00\x00\x00\x02\x00\x00\x00\x00")
@@ -70,7 +69,7 @@ module AMQ
         end
       end
 
-      describe TuneOk do
+      RSpec.describe TuneOk do
         describe '.encode' do
           it 'encodes the parameters into a MethodFrame' do
             channel_max = 0
@@ -81,8 +80,8 @@ module AMQ
           end
         end
       end
-      
-      describe Open do
+
+      RSpec.describe Open do
         describe '.encode' do
           it 'encodes the parameters into a MethodFrame' do
             vhost = '/test'
@@ -91,37 +90,37 @@ module AMQ
           end
         end
       end
-      
-      describe OpenOk do
+
+      RSpec.describe OpenOk do
         describe '.decode' do
           subject do
             OpenOk.decode("\x00")
           end
-          
+
           its(:known_hosts) { should eq('') }
         end
       end
-      
-      describe Close do
+
+      RSpec.describe Close do
         describe '.decode' do
           context 'with code 200' do
             subject do
               Close.decode("\x00\xc8\x07KTHXBAI\x00\x05\x00\x06")
             end
-          
+
             its(:reply_code) { should eq(200) }
             its(:reply_text) { should eq('KTHXBAI') }
             its(:class_id) { should eq(5) }
             its(:method_id) { should eq(6) }
           end
-          
+
           context 'with an error code' do
             it 'returns method frame and lets calling code handle the issue' do
               Close.decode("\x01\x38\x08NO_ROUTE\x00\x00")
             end
           end
         end
-        
+
         describe '.encode' do
           it 'encodes the parameters into a MethodFrame' do
             reply_code = 540
@@ -133,8 +132,8 @@ module AMQ
           end
         end
       end
-      
-      describe CloseOk do
+
+      RSpec.describe CloseOk do
         describe '.encode' do
           it 'encodes a MethodFrame' do
             method_frame = CloseOk.encode

--- a/spec/amq/protocol/connection_spec.rb
+++ b/spec/amq/protocol/connection_spec.rb
@@ -1,7 +1,5 @@
 # encoding: binary
 
-require File.expand_path('../../../spec_helper', __FILE__)
-
 
 module AMQ
   module Protocol

--- a/spec/amq/protocol/constants_spec.rb
+++ b/spec/amq/protocol/constants_spec.rb
@@ -1,5 +1,3 @@
-# encoding: binary
-
 RSpec.describe "(Some) AMQ::Protocol constants" do
   it "include regular port" do
     expect(AMQ::Protocol::DEFAULT_PORT).to eq(5672)

--- a/spec/amq/protocol/constants_spec.rb
+++ b/spec/amq/protocol/constants_spec.rb
@@ -1,6 +1,6 @@
 # encoding: binary
 
-describe "(Some) AMQ::Protocol constants" do
+RSpec.describe "(Some) AMQ::Protocol constants" do
   it "include regular port" do
     expect(AMQ::Protocol::DEFAULT_PORT).to eq(5672)
   end

--- a/spec/amq/protocol/constants_spec.rb
+++ b/spec/amq/protocol/constants_spec.rb
@@ -1,7 +1,5 @@
 # encoding: binary
 
-require File.expand_path('../../../spec_helper', __FILE__)
-
 describe "(Some) AMQ::Protocol constants" do
   it "include regular port" do
     expect(AMQ::Protocol::DEFAULT_PORT).to eq(5672)

--- a/spec/amq/protocol/exchange_spec.rb
+++ b/spec/amq/protocol/exchange_spec.rb
@@ -1,7 +1,5 @@
 # encoding: binary
 
-require File.expand_path('../../../spec_helper', __FILE__)
-
 
 module AMQ
   module Protocol

--- a/spec/amq/protocol/exchange_spec.rb
+++ b/spec/amq/protocol/exchange_spec.rb
@@ -1,10 +1,9 @@
 # encoding: binary
 
-
 module AMQ
   module Protocol
     class Exchange
-      describe Declare do
+      RSpec.describe Declare do
         describe '.encode' do
           it 'encodes the parameters into a MethodFrame' do
             channel = 1
@@ -23,7 +22,7 @@ module AMQ
         end
       end
 
-      describe Declare, "encoded with a symbol name" do
+      RSpec.describe Declare, "encoded with a symbol name" do
         describe '.encode' do
           it 'encodes the parameters into a MethodFrame' do
             channel = 1
@@ -42,7 +41,7 @@ module AMQ
         end
       end
 
-      describe Delete do
+      RSpec.describe Delete do
         describe '.encode' do
           it 'encodes the parameters into a MethodFrame' do
             channel = 1
@@ -56,12 +55,12 @@ module AMQ
         end
       end
 
-      # describe DeleteOk do
+      # RSpec.describe DeleteOk do
       #   describe '.decode' do
       #   end
       # end
 
-      describe Bind do
+      RSpec.describe Bind do
         describe '.encode' do
           it 'encodes the parameters into a MethodFrame' do
             channel = 1
@@ -77,12 +76,12 @@ module AMQ
         end
       end
 
-      # describe BindOk do
+      # RSpec.describe BindOk do
       #   describe '.decode' do
       #   end
       # end
 
-      describe Unbind do
+      RSpec.describe Unbind do
         describe '.encode' do
           it 'encodes the parameters into a MethodFrame' do
             channel = 1
@@ -98,7 +97,7 @@ module AMQ
         end
       end
 
-      # describe UnbindOk do
+      # RSpec.describe UnbindOk do
       #   describe '.decode' do
       #   end
       # end

--- a/spec/amq/protocol/frame_spec.rb
+++ b/spec/amq/protocol/frame_spec.rb
@@ -1,6 +1,3 @@
-# encoding: utf-8
-
-
 module AMQ
   module Protocol
     RSpec.describe Frame do

--- a/spec/amq/protocol/frame_spec.rb
+++ b/spec/amq/protocol/frame_spec.rb
@@ -1,7 +1,5 @@
 # encoding: utf-8
 
-require File.expand_path('../../../spec_helper', __FILE__)
-
 
 module AMQ
   module Protocol

--- a/spec/amq/protocol/frame_spec.rb
+++ b/spec/amq/protocol/frame_spec.rb
@@ -3,7 +3,7 @@
 
 module AMQ
   module Protocol
-    describe Frame do
+    RSpec.describe Frame do
       describe ".encode" do
         it "should raise FrameTypeError if type isn't one of: [:method, :header, :body, :heartbeat]" do
           expect { Frame.encode(nil, "", 0) }.to raise_error(FrameTypeError)

--- a/spec/amq/protocol/method_spec.rb
+++ b/spec/amq/protocol/method_spec.rb
@@ -1,6 +1,3 @@
-# encoding: binary
-
-
 module AMQ
   module Protocol
     RSpec.describe Method do

--- a/spec/amq/protocol/method_spec.rb
+++ b/spec/amq/protocol/method_spec.rb
@@ -3,7 +3,7 @@
 
 module AMQ
   module Protocol
-    describe Method do
+    RSpec.describe Method do
       describe '.split_headers' do
         it 'splits user defined headers into properties and headers' do
           input = {:delivery_mode => 2, :content_type => 'application/octet-stream', :foo => 'bar'}
@@ -12,7 +12,7 @@ module AMQ
           expect(headers).to eq({:foo => 'bar'})
         end
       end
-      
+
       describe '.encode_body' do
         context 'when the body fits in a single frame' do
           it 'encodes a body into a BodyFrame' do

--- a/spec/amq/protocol/method_spec.rb
+++ b/spec/amq/protocol/method_spec.rb
@@ -1,7 +1,5 @@
 # encoding: binary
 
-require File.expand_path('../../../spec_helper', __FILE__)
-
 
 module AMQ
   module Protocol

--- a/spec/amq/protocol/queue_spec.rb
+++ b/spec/amq/protocol/queue_spec.rb
@@ -1,7 +1,5 @@
 # encoding: binary
 
-require File.expand_path('../../../spec_helper', __FILE__)
-
 
 module AMQ
   module Protocol

--- a/spec/amq/protocol/queue_spec.rb
+++ b/spec/amq/protocol/queue_spec.rb
@@ -1,10 +1,9 @@
 # encoding: binary
 
-
 module AMQ
   module Protocol
     class Queue
-      describe Declare do
+      RSpec.describe Declare do
         describe '.encode' do
           it 'encodes the parameters into a MethodFrame' do
             channel = 1
@@ -22,19 +21,19 @@ module AMQ
         end
       end
 
-      describe DeclareOk do
+      RSpec.describe DeclareOk do
         describe '.decode' do
           subject do
             DeclareOk.decode(" amq.gen-KduGSqQrpeUo1otnU0TWSA==\x00\x00\x00\x00\x00\x00\x00\x00")
           end
-          
+
           its(:queue) { should eq('amq.gen-KduGSqQrpeUo1otnU0TWSA==') }
           its(:message_count) { should eq(0) }
           its(:consumer_count) { should eq(0) }
         end
       end
 
-      describe Bind do
+      RSpec.describe Bind do
         describe '.encode' do
           it 'encodes the parameters into a MethodFrame' do
             channel = 1
@@ -50,12 +49,12 @@ module AMQ
         end
       end
 
-      # describe BindOk do
+      # RSpec.describe BindOk do
       #   describe '.decode' do
       #   end
       # end
 
-      describe Purge do
+      RSpec.describe Purge do
         describe '.encode' do
           it 'encodes the parameters into a MethodFrame' do
             channel = 1
@@ -68,17 +67,17 @@ module AMQ
         end
       end
 
-      describe PurgeOk do
+      RSpec.describe PurgeOk do
         describe '.decode' do
           subject do
             PurgeOk.decode("\x00\x00\x00\x02")
           end
-          
+
           its(:message_count) { should eq(2) }
         end
       end
 
-      describe Delete do
+      RSpec.describe Delete do
         describe '.encode' do
           it 'encodes the parameters into a MethodFrame' do
             channel = 1
@@ -93,17 +92,17 @@ module AMQ
         end
       end
 
-      describe DeleteOk do
+      RSpec.describe DeleteOk do
         describe '.decode' do
           subject do
             DeleteOk.decode("\x00\x00\x00\x02")
           end
-          
+
           its(:message_count) { should eq(2) }
         end
       end
 
-      describe Unbind do
+      RSpec.describe Unbind do
         describe '.encode' do
           it 'encodes the parameters into a MethodFrame' do
             channel = 1
@@ -118,7 +117,7 @@ module AMQ
         end
       end
 
-      # describe UnbindOk do
+      # RSpec.describe UnbindOk do
       #   describe '.decode' do
       #   end
       # end

--- a/spec/amq/protocol/table_spec.rb
+++ b/spec/amq/protocol/table_spec.rb
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 
-require File.expand_path('../../../spec_helper', __FILE__)
 require 'bigdecimal'
 require 'time'
 

--- a/spec/amq/protocol/table_spec.rb
+++ b/spec/amq/protocol/table_spec.rb
@@ -3,14 +3,12 @@
 require 'bigdecimal'
 require 'time'
 
-
 module AMQ
   module Protocol
-    describe Table do
+    RSpec.describe Table do
       timestamp    = Time.utc(2010, 12, 31, 23, 58, 59)
       bigdecimal_1 = BigDecimal.new("1.0")
       bigdecimal_2 = BigDecimal.new("5E-3")
-
 
       DATA = {
           {}                       => "\x00\x00\x00\x00",

--- a/spec/amq/protocol/table_spec.rb
+++ b/spec/amq/protocol/table_spec.rb
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 require 'bigdecimal'
 require 'time'
 

--- a/spec/amq/protocol/tx_spec.rb
+++ b/spec/amq/protocol/tx_spec.rb
@@ -1,10 +1,9 @@
 # encoding: binary
 
-
 module AMQ
   module Protocol
     class Tx
-      describe Select do
+      RSpec.describe Select do
         describe '.encode' do
           it 'encodes the parameters into a MethodFrame' do
             channel = 1
@@ -15,12 +14,12 @@ module AMQ
         end
       end
 
-      # describe SelectOk do
+      # RSpec.describe SelectOk do
       #   describe '.decode' do
       #   end
       # end
 
-      describe Commit do
+      RSpec.describe Commit do
         describe '.encode' do
           it 'encodes the parameters into a MethodFrame' do
             channel = 1
@@ -30,13 +29,13 @@ module AMQ
           end
         end
       end
-      
-      # describe CommitOk do
+
+      # RSpec.describe CommitOk do
       #   describe '.decode' do
       #   end
       # end
 
-      describe Rollback do
+      RSpec.describe Rollback do
         describe '.encode' do
           it 'encodes the parameters into a MethodFrame' do
             channel = 1
@@ -47,7 +46,7 @@ module AMQ
         end
       end
 
-      # describe RollbackOk do
+      # RSpec.describe RollbackOk do
       #   describe '.decode' do
       #   end
       # end

--- a/spec/amq/protocol/tx_spec.rb
+++ b/spec/amq/protocol/tx_spec.rb
@@ -1,7 +1,5 @@
 # encoding: binary
 
-require File.expand_path('../../../spec_helper', __FILE__)
-
 
 module AMQ
   module Protocol

--- a/spec/amq/protocol/value_decoder_spec.rb
+++ b/spec/amq/protocol/value_decoder_spec.rb
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 require 'time'
 require "amq/protocol/table_value_decoder"
 

--- a/spec/amq/protocol/value_decoder_spec.rb
+++ b/spec/amq/protocol/value_decoder_spec.rb
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-require File.expand_path('../../../spec_helper', __FILE__)
 
 require 'time'
 require "amq/protocol/table_value_decoder"

--- a/spec/amq/protocol/value_decoder_spec.rb
+++ b/spec/amq/protocol/value_decoder_spec.rb
@@ -5,7 +5,7 @@ require "amq/protocol/table_value_decoder"
 
 module AMQ
   module Protocol
-    describe TableValueDecoder do
+    RSpec.describe TableValueDecoder do
 
       it "is capable of decoding basic arrays TableValueEncoder encodes" do
         input1 = [1, 2, 3]

--- a/spec/amq/protocol/value_encoder_spec.rb
+++ b/spec/amq/protocol/value_encoder_spec.rb
@@ -6,8 +6,7 @@ require "amq/protocol/float_32bit"
 
 module AMQ
   module Protocol
-    describe TableValueEncoder do
-
+    RSpec.describe TableValueEncoder do
 
       it "calculates size of string field values" do
         expect(described_class.field_value_size("amqp")).to eq(9)

--- a/spec/amq/protocol/value_encoder_spec.rb
+++ b/spec/amq/protocol/value_encoder_spec.rb
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-require File.expand_path('../../../spec_helper', __FILE__)
 
 require 'time'
 require "amq/protocol/table_value_encoder"

--- a/spec/amq/protocol/value_encoder_spec.rb
+++ b/spec/amq/protocol/value_encoder_spec.rb
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 require 'time'
 require "amq/protocol/table_value_encoder"
 require "amq/protocol/float_32bit"

--- a/spec/amq/protocol_spec.rb
+++ b/spec/amq/protocol_spec.rb
@@ -1,6 +1,3 @@
-# encoding: binary
-
-
 module AMQ
   RSpec.describe Protocol do
     it "should have PROTOCOL_VERSION constant" do

--- a/spec/amq/protocol_spec.rb
+++ b/spec/amq/protocol_spec.rb
@@ -1,7 +1,5 @@
 # encoding: binary
 
-require File.expand_path('../../spec_helper', __FILE__)
-
 
 module AMQ
   describe Protocol do

--- a/spec/amq/protocol_spec.rb
+++ b/spec/amq/protocol_spec.rb
@@ -2,7 +2,7 @@
 
 
 module AMQ
-  describe Protocol do
+  RSpec.describe Protocol do
     it "should have PROTOCOL_VERSION constant" do
       expect(Protocol::PROTOCOL_VERSION).to match(/^\d+\.\d+\.\d$/)
     end

--- a/spec/amq/settings_spec.rb
+++ b/spec/amq/settings_spec.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 require "amq/settings"
 
 RSpec.describe AMQ::Settings do

--- a/spec/amq/settings_spec.rb
+++ b/spec/amq/settings_spec.rb
@@ -1,6 +1,5 @@
 # encoding: utf-8
 
-require "spec_helper"
 require "amq/settings"
 
 describe AMQ::Settings do

--- a/spec/amq/settings_spec.rb
+++ b/spec/amq/settings_spec.rb
@@ -2,7 +2,7 @@
 
 require "amq/settings"
 
-describe AMQ::Settings do
+RSpec.describe AMQ::Settings do
   describe ".default" do
     it "should provide some default values" do
       expect(AMQ::Settings.default).to_not be_nil

--- a/spec/amq/uri_parsing_spec.rb
+++ b/spec/amq/uri_parsing_spec.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 require "amq/uri"
 
 RSpec.describe AMQ::URI do

--- a/spec/amq/uri_parsing_spec.rb
+++ b/spec/amq/uri_parsing_spec.rb
@@ -1,6 +1,5 @@
 # encoding: utf-8
 
-require "spec_helper"
 require "amq/uri"
 
 RSpec.describe AMQ::URI do

--- a/spec/amq/uri_parsing_spec.rb
+++ b/spec/amq/uri_parsing_spec.rb
@@ -3,104 +3,93 @@
 require "spec_helper"
 require "amq/uri"
 
-describe AMQ::URI, ".parse" do
-  context "when schema is not one of [amqp, amqps]" do
-    it "raises ArgumentError" do
-      expect {
-        described_class.parse_amqp_url("http://dev.rabbitmq.com")
-      }.to raise_error(ArgumentError, /amqp or amqps schema/)
+RSpec.describe AMQ::URI do
+  describe ".parse" do
+    subject { described_class.parse(uri) }
+
+    context "schema is not amqp or amqps" do
+      let(:uri) { "http://rabbitmq" }
+
+      it "raises ArgumentError" do
+        expect { subject }.to raise_error(ArgumentError, /amqp or amqps schema/)
+      end
     end
-  end
 
+    context "path" do
+      context "present" do
+        let(:uri) { "amqp://rabbitmq/staging" }
 
-  it "handles amqp:// URIs w/o path part" do
-    val = described_class.parse_amqp_url("amqp://dev.rabbitmq.com")
+        it "parses vhost" do
+          expect(subject[:vhost]).to eq("staging")
+        end
 
-    expect(val[:vhost]).to be_nil # in this case, default / will be used
-    expect(val[:host]).to eq("dev.rabbitmq.com")
-    expect(val[:port]).to eq(5672)
-    expect(val[:scheme]).to eq("amqp")
-    expect(val[:ssl]).to be_falsey
-  end
+        context "with dots" do
+          let(:uri) { "amqp://rabbitmq/staging.critical.subsystem-a" }
 
-  it "handles amqps:// URIs w/o path part" do
-    val = described_class.parse_amqp_url("amqps://dev.rabbitmq.com")
+          it "parses vhost" do
+            expect(subject[:vhost]).to eq("staging.critical.subsystem-a")
+          end
+        end
 
-    expect(val[:vhost]).to be_nil
-    expect(val[:host]).to eq("dev.rabbitmq.com")
-    expect(val[:port]).to eq(5671)
-    expect(val[:scheme]).to eq("amqps")
-    expect(val[:ssl]).to be_truthy
-  end
+        context "with slashes" do
+          let(:uri) { "amqp://rabbitmq/staging/critical/subsystem-a" }
 
+          it "raises ArgumentError" do
+            expect { subject[:vhost] }.to raise_error(ArgumentError)
+          end
+        end
 
-  context "when URI ends in a slash" do
-    it "parses vhost as an empty string" do
-      val = described_class.parse_amqp_url("amqp://dev.rabbitmq.com/")
+        context "with trailing slash" do
+          let(:uri) { "amqp://rabbitmq/" }
 
-      expect(val[:host]).to eq("dev.rabbitmq.com")
-      expect(val[:port]).to eq(5672)
-      expect(val[:scheme]).to eq("amqp")
-      expect(val[:ssl]).to be_falsey
-      expect(val[:vhost]).to eq("")
+          it "parses vhost as an empty string" do
+            expect(subject[:vhost]).to eq("")
+          end
+        end
+
+        context "with trailing escaped slash" do
+          let(:uri) { "amqp://rabbitmq/%2Fstaging" }
+
+          it "parses vhost as string with leading slash" do
+            expect(subject[:vhost]).to eq("/staging")
+          end
+        end
+      end
+
+      context "absent" do
+        let(:uri) { "amqp://rabbitmq" }
+
+        it "fallbacks to default nil vhost" do
+          expect(subject[:vhost]).to be_nil
+        end
+      end
     end
-  end
 
+    context "username and passowrd" do
+      context "present" do
+        let(:uri) { "amqp://alpha:beta@rabbitmq" }
 
-  context "when URI ends in /%2Fvault" do
-    it "parses vhost as /vault" do
-      val = described_class.parse_amqp_url("amqp://dev.rabbitmq.com/%2Fvault")
+        it "parses user and pass" do
+          expect(subject[:user]).to eq("alpha")
+          expect(subject[:pass]).to eq("beta")
+        end
+      end
 
-      expect(val[:host]).to eq("dev.rabbitmq.com")
-      expect(val[:port]).to eq(5672)
-      expect(val[:scheme]).to eq("amqp")
-      expect(val[:ssl]).to be_falsey
-      expect(val[:vhost]).to eq("/vault")
+      context "absent" do
+        let(:uri) { "amqp://rabbitmq" }
+
+        it "fallbacks to nil user and pass" do
+          expect(subject[:user]).to be_nil
+          expect(subject[:pass]).to be_nil
+        end
+      end
     end
-  end
 
-
-  context "when URI is amqp://dev.rabbitmq.com/a.path.without.slashes" do
-    it "parses vhost as a.path.without.slashes" do
-      val = described_class.parse_amqp_url("amqp://dev.rabbitmq.com/a.path.without.slashes")
-
-      expect(val[:host]).to eq("dev.rabbitmq.com")
-      expect(val[:port]).to eq(5672)
-      expect(val[:scheme]).to eq("amqp")
-      expect(val[:ssl]).to be_falsey
-      expect(val[:vhost]).to eq("a.path.without.slashes")
-    end
-  end
-
-  context "when URI is amqp://dev.rabbitmq.com/a/path/with/slashes" do
-    it "raises an ArgumentError" do
-      expect { described_class.parse_amqp_url("amqp://dev.rabbitmq.com/a/path/with/slashes") }.to raise_error(ArgumentError)
-    end
-  end
-
-
-  context "when URI has username:password, for instance, amqp://hedgehog:t0ps3kr3t@hub.megacorp.internal" do
-    it "parses them out" do
-      val = described_class.parse_amqp_url("amqp://hedgehog:t0ps3kr3t@hub.megacorp.internal")
-
-      expect(val[:host]).to eq("hub.megacorp.internal")
-      expect(val[:port]).to eq(5672)
-      expect(val[:scheme]).to eq("amqp")
-      expect(val[:ssl]).to be_falsey
-      expect(val[:user]).to eq("hedgehog")
-      expect(val[:pass]).to eq("t0ps3kr3t")
-      expect(val[:vhost]).to be_nil # in this case, default / will be used
-    end
-  end
-
-  subject { described_class.parse(uri) }
-
-  context "schema 'amqp'" do
     context "query parameters" do
       context "present" do
         let(:uri) { "amqp://rabbitmq?heartbeat=10&connection_timeout=100&channel_max=1000&auth_mechanism=plain&auth_mechanism=amqplain" }
 
-        specify "parses parameters" do
+        it "parses client connection parameters" do
           expect(subject[:heartbeat]).to eq(10)
           expect(subject[:connection_timeout]).to eq(100)
           expect(subject[:channel_max]).to eq(1000)
@@ -111,7 +100,7 @@ describe AMQ::URI, ".parse" do
       context "absent" do
         let(:uri) { "amqp://rabbitmq" }
 
-        it "fallbacks to defaults" do
+        it "fallbacks to default client connection parameters" do
           expect(subject[:heartbeat]).to be_nil
           expect(subject[:connection_timeout]).to be_nil
           expect(subject[:channel_max]).to be_nil
@@ -119,51 +108,45 @@ describe AMQ::URI, ".parse" do
         end
       end
 
-      context "tls parameters" do
-        %w(verify fail_if_no_peer_cert cacertfile certfile keyfile).each do |tls_param|
-          describe "'verify'" do
-            let(:uri) { "amqp://rabbitmq?#{tls_param}=true" }
+      context "schema amqp" do
+        context "tls parameters" do
+          %w(verify fail_if_no_peer_cert cacertfile certfile keyfile).each do |tls_param|
+            describe "#{tls_param}" do
+              let(:uri) { "amqp://rabbitmq?#{tls_param}=value" }
 
-            it "raises ArgumentError" do
-              expect { subject }.to raise_error(ArgumentError, /The option '#{tls_param}' can only be used in URIs that use amqps for schema/)
+              it "raises ArgumentError" do
+                expect { subject }.to raise_error(ArgumentError, /The option '#{tls_param}' can only be used in URIs that use amqps schema/)
+              end
             end
           end
         end
       end
-    end
-  end
 
-  context "schema 'amqps'" do
-    context "query parameters" do
-      context "present" do
-        let(:uri) { "amqps://rabbitmq?heartbeat=10&connection_timeout=100&channel_max=1000&auth_mechanism=plain&auth_mechanism=amqplain&verify=true&fail_if_no_peer_cert=true&cacertfile=/examples/tls/cacert.pem&certfile=/examples/tls/client_cert.pem&keyfile=/examples/tls/client_key.pem" }
+      context "schema amqps" do
+        context "tls parameters" do
+          context "present" do
+            let(:uri) { "amqps://rabbitmq?verify=true&fail_if_no_peer_cert=true&cacertfile=/examples/tls/cacert.pem&certfile=/examples/tls/client_cert.pem&keyfile=/examples/tls/client_key.pem" }
 
-        it "parses parameters" do
-          expect(subject[:heartbeat]).to eq(10)
-          expect(subject[:connection_timeout]).to eq(100)
-          expect(subject[:channel_max]).to eq(1000)
-          expect(subject[:auth_mechanism]).to eq(["plain", "amqplain"])
-          expect(subject[:verify]).to be_truthy
-          expect(subject[:fail_if_no_peer_cert]).to be_truthy
-          expect(subject[:cacertfile]).to eq("/examples/tls/cacert.pem")
-          expect(subject[:certfile]).to eq("/examples/tls/client_cert.pem")
-          expect(subject[:keyfile]).to eq("/examples/tls/client_key.pem")
+            it "parses tls options" do
+              expect(subject[:verify]).to be_truthy
+              expect(subject[:fail_if_no_peer_cert]).to be_truthy
+              expect(subject[:cacertfile]).to eq("/examples/tls/cacert.pem")
+              expect(subject[:certfile]).to eq("/examples/tls/client_cert.pem")
+              expect(subject[:keyfile]).to eq("/examples/tls/client_key.pem")
+            end
+          end
+
+          context "absent" do
+          let(:uri) { "amqps://rabbitmq" }
+
+          it "fallbacks to default tls options" do
+            expect(subject[:verify]).to be_falsey
+            expect(subject[:fail_if_no_peer_cert]).to be_falsey
+            expect(subject[:cacertfile]).to be_nil
+            expect(subject[:certfile]).to be_nil
+            expect(subject[:keyfile]).to be_nil
+          end
         end
-      end
-
-      context "absent" do
-        let(:uri) { "amqps://rabbitmq" }
-
-        it "fallbacks to defaults" do
-          expect(subject[:heartbeat]).to be_nil
-          expect(subject[:connection_timeout]).to be_nil
-          expect(subject[:channel_max]).to be_nil
-          expect(subject[:auth_mechanism]).to be_empty
-          expect(subject[:verify]).to be_falsey
-          expect(subject[:fail_if_no_peer_cert]).to be_falsey
-          expect(subject[:cacertfile]).to be_nil
-          expect(subject[:certfile]).to be_nil
-          expect(subject[:keyfile]).to be_nil
         end
       end
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,10 +1,7 @@
 # encoding: binary
 
 require 'bundler/setup'
-require 'rspec'
-require 'rspec/its'
-
-require "effin_utf8"
+Bundler.require(:test)
 
 begin
   require 'simplecov'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -23,5 +23,7 @@ RSpec.configure do |config|
 
   config.filter_run_when_matching :focus
 
+  config.disable_monkey_patching!
+
   config.warnings = true
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -24,5 +24,7 @@ puts "Running on #{RUBY_VERSION}"
 RSpec.configure do |config|
   config.include AMQ::Protocol
 
+  config.filter_run_when_matching :focus
+
   config.warnings = true
 end


### PR DESCRIPTION
This is a follow up to #67. 

### Improvements

- Allow [focus](https://relishapp.com/rspec/rspec-core/v/3-7/docs/filtering/filter-run-when-matching) on specs (required upgrade rspec from 3.4.0 to 3.5.0)
- Add `byebug` gem to development and test bundler groups
- Declare `simplecov` gem explicitly in bundle
- Require gems in bundle automatically
- [Require](https://relishapp.com/rspec/rspec-core/v/3-7/docs/command-line/require-option) `spec_helper` within [`.rspec` file](https://relishapp.com/rspec/rspec-core/v/3-7/docs/configuration/read-command-line-configuration-options-from-files)
- Disable [`rspec` money patching](https://relishapp.com/rspec/rspec-core/v/3-7/docs/configuration/zero-monkey-patching-mode)
- Remove redundant ruby file encoding declarations
