### PR TITLE
Extend URI Parsing Specs

### DIFF
--- a/lib/amq/settings.rb
+++ b/lib/amq/settings.rb
@@ -14,23 +14,31 @@ module AMQ
       # @see AMQ::Client::Settings.configure
       def self.default
         @default ||= {
-          # server
-          :host  => "127.0.0.1",
-          :port  => AMQ::Protocol::DEFAULT_PORT,
+          # TCP/IP connection parameters
+          host: "127.0.0.1",
+          port: AMQ::Protocol::DEFAULT_PORT,
+          auth_mechanism: [],
 
-          # login
-          :user  => "guest",
-          :pass  => "guest",
-          :vhost => "/",
+          # authentication parameters
+          user: "guest",
+          pass: "guest",
+          vhost: "/",
 
-          # ssl
-          :ssl => false,
+          # client connection parameters
+          frame_max: (128 * 1024),
+          heartbeat: nil,
+          connection_timeout: nil,
+          channel_max: nil,
 
-          :frame_max => (128 * 1024),
-          :heartbeat => 0
-        }
+          # ssl parameters
+          ssl: false,
+          verify: false,
+          fail_if_no_peer_cert: false,
+          cacertfile: nil,
+          certfile: nil,
+          keyfile: nil
+        }.freeze
       end
-
 
       # Merges given configuration parameters with defaults and returns
       # the result.

--- a/lib/amq/settings.rb
+++ b/lib/amq/settings.rb
@@ -51,9 +51,18 @@ module AMQ
       # @option settings [String] :user ("guest") Username to use for authentication.
       # @option settings [String] :pass ("guest") Password to use for authentication.
       # @option settings [String] :ssl (false) Should be use TLS (SSL) for connection?
-      # @option settings [String] :timeout (nil) Connection timeout.
-      # @option settings [String] :broker (nil) Broker name (use if you intend to use broker-specific features).
       # @option settings [Fixnum] :frame_max (131072) Maximum frame size to use. If broker cannot support frames this large, broker's maximum value will be used instead.
+      # @option settings [Integer] :heartbeat (nil) Heartbeat timeout value in seconds to negotiate with the server.
+      # @option settings [Integer] :connection_timeout (nil) Time in milliseconds to wait while establishing a TCP connection to the server before giving up.
+      # @option settings [Fixnum] :channel_max (nil) Maximum number of channels to permit on this connection.
+      # @option settings [Array] :auth_mechanism ([]) SASL authentication mechanisms to consider when negotiating a mechanism with the server. This parameter can be specified multiple times to specify multiple mechanisms, e.g. `?auth_mechanism=plain&auth_mechanism=amqplain`.
+      # @option settings [Boolean] :verify (false) Controls peer verification mode.
+      # @option settings [Boolean] :fail_if_no_peer_cert (false) When set to true, TLS connection will be rejected if client fails to provide a certificate.
+      # @option settings [String] :cacertfile (nil) Certificate Authority (CA) certificate file path.
+      # @option settings [String] :certfile (nil) Server certificate file path.
+      # @option settings [String] :keyfile (nil) Server private key file path.
+      #
+      # @option settings [String] :broker (nil) Broker name (use if you intend to use broker-specific features).
       #
       # @return [Hash] Merged configuration parameters.
       def self.configure(settings = nil)

--- a/lib/amq/uri.rb
+++ b/lib/amq/uri.rb
@@ -6,10 +6,12 @@ require "uri"
 module AMQ
   class URI
     # @private
-    AMQP_PORTS = {
+    AMQP_DEFAULT_PORTS = {
       "amqp" => 5672,
       "amqps" => 5671
     }.freeze
+
+    private_constant :AMQP_DEFAULT_PORTS
 
     DEFAULTS = {
       heartbeat: nil,
@@ -33,7 +35,7 @@ module AMQ
       opts[:user]   = ::CGI::unescape(uri.user) if uri.user
       opts[:pass]   = ::CGI::unescape(uri.password) if uri.password
       opts[:host]   = uri.host if uri.host
-      opts[:port]   = uri.port || AMQP_PORTS[uri.scheme]
+      opts[:port]   = uri.port || AMQP_DEFAULT_PORTS[uri.scheme]
       opts[:ssl]    = uri.scheme.to_s.downcase =~ /amqps/i # TODO: rename to tls
       if uri.path =~ %r{^/(.*)}
         raise ArgumentError.new("#{uri} has multiple-segment path; please percent-encode any slashes in the vhost name (e.g. /production => %2Fproduction). Learn more at http://bit.ly/amqp-gem-and-connection-uris") if $1.index('/')

--- a/lib/amq/uri.rb
+++ b/lib/amq/uri.rb
@@ -6,7 +6,10 @@ require "uri"
 module AMQ
   class URI
     # @private
-    AMQP_PORTS = {"amqp" => 5672, "amqps" => 5671}.freeze
+    AMQP_PORTS = {
+      "amqp" => 5672,
+      "amqps" => 5671
+    }.freeze
 
     DEFAULTS = {
       heartbeat: nil,

--- a/spec/amq/uri_parsing_spec.rb
+++ b/spec/amq/uri_parsing_spec.rb
@@ -27,18 +27,31 @@ RSpec.describe AMQ::URI do
         context "escaped" do
           let(:uri) { "amqp://r%61bbitmq:5672" }
 
-          it "parses host", pending: '?' do
+          it "parses host", pending: "Need to investigate, why URI module doesn't handle escaped host component..." do
             expect(subject[:host]).to eq("rabbitmq")
           end
         end
       end
 
-      context "absent" do
-        let(:uri) { "amqp://" }
+      if RUBY_VERSION >= "2.2"
+        context "absent" do
+          let(:uri) { "amqp://" }
 
-        # Note that according to the ABNF, the host component may not be absent, but it may be zero-length.
-        it "fallbacks to default nil host" do
-          expect(subject[:host]).to be_nil
+          # Note that according to the ABNF, the host component may not be absent, but it may be zero-length.
+          it "fallbacks to default nil host" do
+            expect(subject[:host]).to be_nil
+          end
+        end
+      end
+
+      if RUBY_VERSION < "2.2"
+        context "absent" do
+          let(:uri) { "amqp://" }
+
+          # Note that according to the ABNF, the host component may not be absent, but it may be zero-length.
+          it "raises InvalidURIError" do
+            expect { subject[:host] }.to raise_error(URI::InvalidURIError, /bad URI\(absolute but no path\)/)
+          end
         end
       end
     end

--- a/spec/amq/uri_parsing_spec.rb
+++ b/spec/amq/uri_parsing_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe AMQ::URI do
           let(:uri) { "amqp://" }
 
           # Note that according to the ABNF, the host component may not be absent, but it may be zero-length.
-          it "fallbacks to default nil host" do
+          it "falls back to default nil host" do
             expect(subject[:host]).to be_nil
           end
         end
@@ -69,7 +69,7 @@ RSpec.describe AMQ::URI do
         context "schema amqp" do
           let(:uri) { "amqp://rabbitmq" }
 
-          it "fallbacks to 5672 port" do
+          it "falls back to 5672 port" do
             expect(subject[:port]).to eq(5672)
           end
         end
@@ -77,7 +77,7 @@ RSpec.describe AMQ::URI do
         context "schema amqps" do
           let(:uri) { "amqps://rabbitmq" }
 
-          it "fallbacks to 5671 port" do
+          it "falls back to 5671 port" do
             expect(subject[:port]).to eq(5671)
           end
         end
@@ -97,7 +97,7 @@ RSpec.describe AMQ::URI do
       context "only username present" do
         let(:uri) { "amqp://alpha@rabbitmq" }
 
-        it "parses user and fallbacks to nil pass" do
+        it "parses user and falls back to nil pass" do
           expect(subject[:user]).to eq("alpha")
           expect(subject[:pass]).to be_nil
         end
@@ -105,7 +105,7 @@ RSpec.describe AMQ::URI do
         context "with ':'" do
           let(:uri) { "amqp://alpha:@rabbitmq" }
 
-          it "parses user and fallbacks to "" (empty) pass" do
+          it "parses user and falls back to "" (empty) pass" do
             expect(subject[:user]).to eq("alpha")
             expect(subject[:pass]).to eq("")
           end
@@ -115,7 +115,7 @@ RSpec.describe AMQ::URI do
       context "only password present" do
         let(:uri) { "amqp://:beta@rabbitmq" }
 
-        it "parses pass and fallbacks to "" (empty) user" do
+        it "parses pass and falls back to "" (empty) user" do
           expect(subject[:user]).to eq("")
           expect(subject[:pass]).to eq("beta")
         end
@@ -124,7 +124,7 @@ RSpec.describe AMQ::URI do
       context "both absent" do
         let(:uri) { "amqp://rabbitmq" }
 
-        it "fallbacks to nil user and pass" do
+        it "falls back to nil user and pass" do
           expect(subject[:user]).to be_nil
           expect(subject[:pass]).to be_nil
         end
@@ -132,7 +132,7 @@ RSpec.describe AMQ::URI do
         context "with ':'" do
           let(:uri) { "amqp://:@rabbitmq" }
 
-          it "fallbacks to "" (empty) user and "" (empty) pass" do
+          it "falls back to "" (empty) user and "" (empty) pass" do
             expect(subject[:user]).to eq("")
             expect(subject[:pass]).to eq("")
           end
@@ -201,7 +201,7 @@ RSpec.describe AMQ::URI do
       context "absent" do
         let(:uri) { "amqp://rabbitmq" }
 
-        it "fallbacks to default nil vhost" do
+        it "falls back to default nil vhost" do
           expect(subject[:vhost]).to be_nil
         end
       end
@@ -222,7 +222,7 @@ RSpec.describe AMQ::URI do
       context "absent" do
         let(:uri) { "amqp://rabbitmq" }
 
-        it "fallbacks to default client connection parameters" do
+        it "falls back to default client connection parameters" do
           expect(subject[:heartbeat]).to be_nil
           expect(subject[:connection_timeout]).to be_nil
           expect(subject[:channel_max]).to be_nil
@@ -261,7 +261,7 @@ RSpec.describe AMQ::URI do
           context "absent" do
           let(:uri) { "amqps://rabbitmq" }
 
-          it "fallbacks to default tls options" do
+          it "falls back to default tls options" do
             expect(subject[:verify]).to be_falsey
             expect(subject[:fail_if_no_peer_cert]).to be_falsey
             expect(subject[:cacertfile]).to be_nil

--- a/spec/amq/uri_parsing_spec.rb
+++ b/spec/amq/uri_parsing_spec.rb
@@ -24,10 +24,10 @@ RSpec.describe AMQ::URI do
           expect(subject[:host]).to eq("rabbitmq")
         end
 
-        context "escaped" do
+        context "%-encoded" do
           let(:uri) { "amqp://r%61bbitmq:5672" }
 
-          it "parses host", pending: "Need to investigate, why URI module doesn't handle escaped host component..." do
+          it "parses host", pending: "Need to investigate, why URI module doesn't handle %-encoded host component..." do
             expect(subject[:host]).to eq("rabbitmq")
           end
         end
@@ -139,7 +139,7 @@ RSpec.describe AMQ::URI do
         end
       end
 
-      context "escaped" do
+      context "%-encoded" do
         let(:uri) { "amqp://%61lpha:bet%61@rabbitmq" }
 
         it "parses user and pass" do
@@ -181,7 +181,7 @@ RSpec.describe AMQ::URI do
           end
         end
 
-        context "with trailing escaped slash" do
+        context "with trailing %-encoded slash" do
           let(:uri) { "amqp://rabbitmq/%2Fstaging" }
 
           it "parses vhost as string with leading slash" do
@@ -189,7 +189,7 @@ RSpec.describe AMQ::URI do
           end
         end
 
-        context "escaped" do
+        context "%-encoded" do
           let(:uri) { "amqp://rabbitmq/%2Fstaging%2Fcritical%2Fsubsystem-a" }
 
           it "parses vhost as string with leading slash" do


### PR DESCRIPTION
Before we adopt URI query params in **bunny** and **amqp**, I'd like to polish specs for URI in **amq-protocol**. While I was investigating the code, I met some non-intuitive places that would like to discuss. I guess it's better to talk about them here in PR as far as I tackled required places, or at least start here and move to GitHub issues if needed.