### PR TITLE
Dup Default Settings

### DIFF
--- a/lib/amq/settings.rb
+++ b/lib/amq/settings.rb
@@ -82,7 +82,7 @@ module AMQ
           settings = self.parse_amqp_url(settings)
           self.default.merge(settings)
         when NilClass then
-          self.default
+          self.default.dup
         end
       end
 


### PR DESCRIPTION
Duplicate freezed default settings hash for further transformation inside the client.

Cross-Reference: ruby-amqp/amqp#237