### PR TITLE
Removing effin utf-8 gem dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,6 @@ end
 group :test do
   gem "rspec", ">= 3.5.0"
   gem "rspec-its"
-  gem "effin_utf8"
   gem "simplecov"
 end
 


### PR DESCRIPTION
Since recent amq-protocol releases drop support for ruby 1.x versions, there is no need to use this gem anymore. utf8 is the default encoding in ruby 2.x versions.
