### PR TITLE
Allow frozen strings in message bodies

### DIFF
--- a/lib/amq/protocol/client.rb
+++ b/lib/amq/protocol/client.rb
@@ -174,7 +174,7 @@ module AMQ
 
         # Otherwise String#slice on 1.9 will operate with code points,
         # and we need bytes. MK.
-        body.force_encoding("ASCII-8BIT") if RUBY_VERSION.to_f >= 1.9
+        body.force_encoding("ASCII-8BIT") if RUBY_VERSION.to_f >= 1.9 && body.encoding != Encoding::BINARY
 
         array = Array.new
         while body && !body.empty?


### PR DESCRIPTION
Previously, this didn't work because `force_encoding` would always be called on the string, which raises an error on frozen strings, even if the forced encoding is the same as the existing encoding.

Now, the encoding is only changed if the given encoding is wrong (non-binary). This means that correctly encoded frozen strings won't be modified.